### PR TITLE
Add node selectors to allow pods to run on desired nodes

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# source the functions in labels.sh
+. labels.sh
+
+FT_LABEL_ACTION=delete
+manage_labels
+
+kubectl delete -f clientDaemonSet.yaml
+kubectl delete -f serverPod-v4.yaml
+kubectl delete -f svc_nodePort.yaml
+
+kubectl delete -f clientDaemonSet-host.yaml
+kubectl delete -f serverPod-host-v4.yaml
+kubectl delete -f svc_host_nodePort.yaml
+

--- a/labels.sh
+++ b/labels.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+
+# 
+FT_LABEL_ACTION=${FT_LABEL_ACTION:-}
+FT_REQ_SERVER_NODE=${FT_REQ_SERVER_NODE:-all}
+
+FT_SERVER_NODE_LABEL=ft.ServerPod
+
+manage_labels() {
+  echo "Label Management:"
+  echo "  FT_LABEL_ACTION            $FT_LABEL_ACTION"
+  echo "  FT_REQ_SERVER_NODE         $FT_REQ_SERVER_NODE"
+  echo "  FT_SERVER_NODE_LABEL       $FT_SERVER_NODE_LABEL"
+
+  FOUND_NODE=false
+  NODE_ARRAY=($(kubectl get nodes --no-headers=true | awk -F' ' '{print $1}'))
+  for i in "${!NODE_ARRAY[@]}"
+  do
+    if [ "$FT_LABEL_ACTION" == add ]; then
+      # Check for non-master (KIND clusters don't have "worker" role set)
+      kubectl get node ${NODE_ARRAY[$i]}  --no-headers=true | awk -F' ' '{print $3}' | grep -q master
+      if [ "$?" == 1 ]; then
+        echo "${NODE_ARRAY[$i]} is worker"
+        if [ "$FOUND_NODE" == false ] && [ "$FT_REQ_SERVER_NODE" == all ] || [ "$FT_REQ_SERVER_NODE" == "${NODE_ARRAY[$i]}" ]; then
+          echo "  Applying Server Label \"$FT_SERVER_NODE_LABEL\" to ${NODE_ARRAY[$i]}"
+          kubectl label nodes ${NODE_ARRAY[$i]} $FT_SERVER_NODE_LABEL=server
+          FOUND_NODE=true
+        else
+          kubectl label nodes ${NODE_ARRAY[$i]} $FT_SERVER_NODE_LABEL=none
+        fi
+      fi
+    fi
+
+    if [ "$FT_LABEL_ACTION" == delete ]; then
+      # Check for non-master (KIND clusters don't have "worker" role set)
+      kubectl get node ${NODE_ARRAY[$i]}  --no-headers=true | awk -F' ' '{print $3}' | grep -q master
+      if [ "$?" == 1 ]; then
+        echo "${NODE_ARRAY[$i]} is worker"
+
+        echo "  Removing Server Label \"$FT_SERVER_NODE_LABEL\" from ${NODE_ARRAY[$i]}"
+        kubectl label nodes ${NODE_ARRAY[$i]} $FT_SERVER_NODE_LABEL- >/dev/null
+      fi
+    fi
+  done
+}

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# source the functions in labels.sh
+. labels.sh
+
+FT_LABEL_ACTION=add
+manage_labels
+
+kubectl apply -f svc_nodePort.yaml
+kubectl apply -f serverPod-v4.yaml
+kubectl apply -f clientDaemonSet.yaml
+
+kubectl apply -f svc_host_nodePort.yaml
+kubectl apply -f serverPod-host-v4.yaml
+kubectl apply -f clientDaemonSet-host.yaml
+

--- a/serverPod-host-v4.yaml
+++ b/serverPod-host-v4.yaml
@@ -34,6 +34,8 @@ spec:
       - "python"
     args: ["-m", "http.server", "8081", "--directory", "/etc/webserver/"]
     imagePullPolicy: IfNotPresent
+  nodeSelector:
+    ft.ServerPod: server
   volumes:
   - name: webserver-index
     configMap:

--- a/serverPod-v4.yaml
+++ b/serverPod-v4.yaml
@@ -33,6 +33,8 @@ spec:
       - "python"
     args: ["-m", "http.server", "8080", "--directory", "/etc/webserver/"]
     imagePullPolicy: IfNotPresent
+  nodeSelector:
+    ft.ServerPod: server
   volumes:
   - name: webserver-index
     configMap:


### PR DESCRIPTION
For certian scenarios, like HW Offload, it may be desirable to run the pods
on specific nodes. Added this functionality via node labels and overidable
environmental variables.

To make sure all the combinations of local/remote and pod/host are handled
properly, force the server pods to run on the same node, and the selected
remote clients are on the same nodes. Remote client node is now configurable.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>