### PR TITLE
Add namespace to all yaml files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository contains the yaml files and test scripts to test all the traffic
      - [Pin Remote Client to Given Node](#pin-remote-client-to-given-node)
      - [Limit Test to Only Host-Backed Pods](#limit-test-to-only-host-backed-pods)
      - [Deploy With SR-IOV VFs](#deploy-with-sr-iov-vfs)
+     - [Manage Namespace](#manage-namespace)
      - [Check Variable Settings](#check-variable-settings)
   - [Cleanup Test Pods](#cleanup-test-pods)
   - [Deployment Customization](#deployment-customization)
@@ -223,6 +224,20 @@ kubectl label nodes ovn-worker5 sriov-node=
 export FT_SRIOV_NODE_LABEL=sriov-node"
 export SRIOV_RESOURCE_NAME=sriov_a"
 ./launch.sh
+```
+
+#### Manage Namespace
+
+By default, all objects (pods, daemonsets, services, etc) are created in the
+`default` namespace. This can be overwritten by using the `FT_NAMESPACE` variable.
+`launch.sh`, `test.sh` and `cleanup.sh` all need the same value set, so it is best
+to export this variable when using.
+
+```
+export FT_NAMESPACE=flow-test
+./launch.sh
+./test.sh
+./cleanup.sh
 ```
 
 #### Check Variable Settings

--- a/generate-yaml.sh
+++ b/generate-yaml.sh
@@ -36,20 +36,29 @@ install_j2_renderer() {
 generate_yamls() {
 
   #
+  # Namespace
+  #
+  namespace=${FT_NAMESPACE} \
+  j2 "./manifests/namespace.yaml.j2" -o "./manifests/yamls/namespace.yaml"
+
+  #
   # Client Pods
   #
 
   # client-daemonSet-host.yaml
+  namespace=${FT_NAMESPACE} \
   test_image=${TEST_IMAGE} \
   j2 "./manifests/client-daemonSet-host.yaml.j2" -o "./manifests/yamls/client-daemonSet-host.yaml"
 
   # client-daemonSet-sriov.yaml
+  namespace=${FT_NAMESPACE} \
   net_attach_def_name=${NET_ATTACH_DEF_NAME} \
   sriov_resource_name=${SRIOV_RESOURCE_NAME} \
   test_image=${TEST_IMAGE} \
   j2 "./manifests/client-daemonSet-sriov.yaml.j2" -o "./manifests/yamls/client-daemonSet-sriov.yaml"
 
   # client-daemonSet.yaml
+  namespace=${FT_NAMESPACE} \
   test_image=${TEST_IMAGE} \
   j2 "./manifests/client-daemonSet.yaml.j2" -o "./manifests/yamls/client-daemonSet.yaml"
 
@@ -58,16 +67,19 @@ generate_yamls() {
   #
 
   # http-server-pod-v4-host.yaml
+  namespace=${FT_NAMESPACE} \
   http_clusterip_host_svc_port=${HTTP_CLUSTERIP_HOST_SVC_PORT} \
   j2 "./manifests/http-server-pod-v4-host.yaml.j2" -o "./manifests/yamls/http-server-pod-v4-host.yaml"
 
   # http-server-pod-v4-sriov
+  namespace=${FT_NAMESPACE} \
   net_attach_def_name=${NET_ATTACH_DEF_NAME} \
   sriov_resource_name=${SRIOV_RESOURCE_NAME} \
   http_clusterip_pod_svc_port=${HTTP_CLUSTERIP_POD_SVC_PORT} \
   j2 "./manifests/http-server-pod-v4-sriov.yaml.j2" -o "./manifests/yamls/http-server-pod-v4-sriov.yaml"
 
   # http-server-pod-v4.yaml
+  namespace=${FT_NAMESPACE} \
   http_clusterip_pod_svc_port=${HTTP_CLUSTERIP_POD_SVC_PORT} \
   j2 "./manifests/http-server-pod-v4.yaml.j2" -o "./manifests/yamls/http-server-pod-v4.yaml"
 
@@ -76,11 +88,13 @@ generate_yamls() {
   #
 
   # iperf-server-pod-v4-host.yaml
+  namespace=${FT_NAMESPACE} \
   test_image=${TEST_IMAGE} \
   iperf_clusterip_host_svc_port=${IPERF_CLUSTERIP_HOST_SVC_PORT} \
   j2 "./manifests/iperf-server-pod-v4-host.yaml.j2" -o "./manifests/yamls/iperf-server-pod-v4-host.yaml"
 
   # iperf-server-pod-v4-sriov.yaml
+  namespace=${FT_NAMESPACE} \
   net_attach_def_name=${NET_ATTACH_DEF_NAME} \
   sriov_resource_name=${SRIOV_RESOURCE_NAME} \
   test_image=${TEST_IMAGE} \
@@ -88,6 +102,7 @@ generate_yamls() {
   j2 "./manifests/iperf-server-pod-v4-sriov.yaml.j2" -o "./manifests/yamls/iperf-server-pod-v4-sriov.yaml"
 
   # iperf-server-pod-v4.yaml
+  namespace=${FT_NAMESPACE} \
   test_image=${TEST_IMAGE} \
   iperf_clusterip_pod_svc_port=${IPERF_CLUSTERIP_POD_SVC_PORT} \
   j2 "./manifests/iperf-server-pod-v4.yaml.j2" -o "./manifests/yamls/iperf-server-pod-v4.yaml"
@@ -98,6 +113,7 @@ generate_yamls() {
   #
 
   # netAttachDef-sriov.yaml
+  namespace=${FT_NAMESPACE} \
   net_attach_def_name=${NET_ATTACH_DEF_NAME} \
   sriov_resource_name=${SRIOV_RESOURCE_NAME} \
   iperf_clusterip_host_svc_port=${IPERF_CLUSTERIP_HOST_SVC_PORT} \
@@ -109,16 +125,19 @@ generate_yamls() {
   #
 
   # svc-clusterIP.yaml
+  namespace=${FT_NAMESPACE} \
   http_clusterip_host_svc_port=${HTTP_CLUSTERIP_HOST_SVC_PORT} \
   iperf_clusterip_host_svc_port=${IPERF_CLUSTERIP_HOST_SVC_PORT} \
   j2 "./manifests/svc-clusterIP-host.yaml.j2" -o "./manifests/yamls/svc-clusterIP-host.yaml"
 
   # svc-clusterIP.yaml
+  namespace=${FT_NAMESPACE} \
   http_clusterip_pod_svc_port=${HTTP_CLUSTERIP_POD_SVC_PORT} \
   iperf_clusterip_pod_svc_port=${IPERF_CLUSTERIP_POD_SVC_PORT} \
   j2 "./manifests/svc-clusterIP.yaml.j2" -o "./manifests/yamls/svc-clusterIP.yaml"
 
   # svc-nodePort-host.yaml
+  namespace=${FT_NAMESPACE} \
   http_clusterip_host_svc_port=${HTTP_CLUSTERIP_HOST_SVC_PORT} \
   http_nodeport_host_svc_port=${HTTP_NODEPORT_HOST_SVC_PORT} \
   iperf_clusterip_host_svc_port=${IPERF_CLUSTERIP_HOST_SVC_PORT} \
@@ -126,6 +145,7 @@ generate_yamls() {
   j2 "./manifests/svc-nodePort-host.yaml.j2" -o "./manifests/yamls/svc-nodePort-host.yaml"
 
   # svc-nodePort.yaml
+  namespace=${FT_NAMESPACE} \
   http_clusterip_pod_svc_port=${HTTP_CLUSTERIP_POD_SVC_PORT} \
   http_nodeport_pod_svc_port=${HTTP_NODEPORT_POD_SVC_PORT} \
   iperf_clusterip_pod_svc_port=${IPERF_CLUSTERIP_POD_SVC_PORT} \

--- a/launch.sh
+++ b/launch.sh
@@ -18,6 +18,7 @@ test_for_kubectl
 #
 
 FT_HOSTONLY=${FT_HOSTONLY:-false}
+FT_NAMESPACE=${FT_NAMESPACE:-default}
 
 NET_ATTACH_DEF_NAME=${NET_ATTACH_DEF_NAME:-ftnetattach}
 SRIOV_RESOURCE_NAME=${SRIOV_RESOURCE_NAME:-openshift.io/mlnx_bf}
@@ -38,6 +39,7 @@ dump-working-data() {
   echo "Default/Override Values:"
   echo "  Launch Control:"
   echo "    FT_HOSTONLY                        $FT_HOSTONLY"
+  echo "    FT_NAMESPACE                       $FT_NAMESPACE"
   echo "    FT_REQ_SERVER_NODE                 $FT_REQ_SERVER_NODE"
   echo "    FT_REQ_REMOTE_CLIENT_NODE          $FT_REQ_REMOTE_CLIENT_NODE"
   echo "    FT_SRIOV_NODE_LABEL                $FT_SRIOV_NODE_LABEL"
@@ -66,6 +68,14 @@ if [ ! -z "$1" ] ; then
     echo "                               false positives could occur if pods are renamed or server pod"
     echo "                               failed to come up. Example:"
     echo "                                 export FT_HOSTONLY=true"
+    echo "                                 ./launch.sh"
+    echo "                                 ./test.sh"
+    echo "                                 ./cleanup.sh"
+    echo "  FT_NAMESPACE               - Namespace for all pods, configMaps and services associated with"
+    echo "                               Flow Tester. Defaults to \"default\" namespace. It is best to"
+    echo "                               export this variable because test.sh and cleanup.sh also need"
+    echo "                               the same value set. Example:"
+    echo "                                 export FT_NAMESPACE=flow-test"
     echo "                                 ./launch.sh"
     echo "                                 ./test.sh"
     echo "                                 ./cleanup.sh"
@@ -108,6 +118,11 @@ FT_SRIOV_SERVER=false
 FT_NORMAL_CLIENT=false
 FT_SRIOV_CLIENT=false
 add_labels
+
+if [ "$FT_NAMESPACE" != default ]; then
+  echo "Creating Namespace"
+  kubectl apply -f ./manifests/yamls/namespace.yaml
+fi
 
 if [ "$FT_HOSTONLY" == false ]; then
   if [ "$FT_SRIOV_SERVER" == true ] || [ "$FT_SRIOV_CLIENT" == true ]; then

--- a/manifests/client-daemonSet-host.yaml.j2
+++ b/manifests/client-daemonSet-host.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ft-client-pod-host
+  namespace: {{ namespace }}
 spec:
   selector:
     matchLabels:

--- a/manifests/client-daemonSet-sriov.yaml.j2
+++ b/manifests/client-daemonSet-sriov.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ft-client-pod-sriov
+  namespace: {{ namespace }}
 spec:
   selector:
     matchLabels:

--- a/manifests/client-daemonSet.yaml.j2
+++ b/manifests/client-daemonSet.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ft-client-pod
+  namespace: {{ namespace }}
 spec:
   selector:
     matchLabels:

--- a/manifests/http-server-pod-v4-host.yaml.j2
+++ b/manifests/http-server-pod-v4-host.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ft-http-server-host-index
+  namespace: {{ namespace }}
 data:
   index.html: |
     <!doctype html>
@@ -19,6 +20,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: ft-http-server-host-v4
+  namespace: {{ namespace }}
   labels:
     pod-name: ft-http-server-host-v4
 spec:

--- a/manifests/http-server-pod-v4-sriov.yaml.j2
+++ b/manifests/http-server-pod-v4-sriov.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ft-http-server-pod-index-sriov
+  namespace: {{ namespace }}
 data:
   index.html: |
     <!doctype html>
@@ -19,6 +20,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: ft-http-server-pod-v4
+  namespace: {{ namespace }}
   annotations:
     v1.multus-cni.io/default-network: default/{{ net_attach_def_name }}
   labels:

--- a/manifests/http-server-pod-v4.yaml.j2
+++ b/manifests/http-server-pod-v4.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ft-http-server-pod-index
+  namespace: {{ namespace }}
 data:
   index.html: |
     <!doctype html>
@@ -19,6 +20,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: ft-http-server-pod-v4
+  namespace: {{ namespace }}
   labels:
     pod-name: ft-http-server-pod-v4
 spec:

--- a/manifests/iperf-server-pod-v4-host.yaml.j2
+++ b/manifests/iperf-server-pod-v4-host.yaml.j2
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: ft-iperf-server-host-v4
+  namespace: {{ namespace }}
   labels:
     pod-name: ft-iperf-server-host-v4
 spec:

--- a/manifests/iperf-server-pod-v4-sriov.yaml.j2
+++ b/manifests/iperf-server-pod-v4-sriov.yaml.j2
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: ft-iperf-server-pod-v4
+  namespace: {{ namespace }}
   annotations:
     v1.multus-cni.io/default-network: default/{{ net_attach_def_name }}
   labels:

--- a/manifests/iperf-server-pod-v4.yaml.j2
+++ b/manifests/iperf-server-pod-v4.yaml.j2
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: ft-iperf-server-pod-v4
+  namespace: {{ namespace }}
   labels:
     pod-name: ft-iperf-server-pod-v4
 spec:

--- a/manifests/namespace.yaml.j2
+++ b/manifests/namespace.yaml.j2
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ namespace }}

--- a/manifests/netAttachDef-sriov.yaml.j2
+++ b/manifests/netAttachDef-sriov.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
   name: {{ net_attach_def_name }}
-  namespace: default
+  namespace: {{ namespace }}
   annotations:
     k8s.v1.cni.cncf.io/resourceName: {{ sriov_resource_name }}
 spec:

--- a/manifests/svc-clusterIP-host.yaml.j2
+++ b/manifests/svc-clusterIP-host.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ft-http-service-clusterip-host-v4
+  namespace: {{ namespace }}
   labels:
     pod-name: ft-http-service-clusterip-host-v4
 spec:
@@ -18,6 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ft-iperf-service-clusterip-host-v4
+  namespace: {{ namespace }}
   labels:
     pod-name: ft-iperf-service-clusterip-host-v4
 spec:

--- a/manifests/svc-clusterIP.yaml.j2
+++ b/manifests/svc-clusterIP.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ft-http-service-clusterip-pod-v4
+  namespace: {{ namespace }}
   labels:
     pod-name: ft-http-service-clusterip-pod-v4
 spec:
@@ -18,6 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ft-iperf-service-clusterip-pod-v4
+  namespace: {{ namespace }}
   labels:
     pod-name: ft-iperf-service-clusterip-pod-v4
 spec:

--- a/manifests/svc-nodePort-host.yaml.j2
+++ b/manifests/svc-nodePort-host.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ft-http-service-nodeport-host-v4
+  namespace: {{ namespace }}
   labels:
     pod-name: ft-http-service-nodeport-host-v4
 spec:
@@ -19,6 +20,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ft-iperf-service-nodeport-host-v4
+  namespace: {{ namespace }}
   labels:
     pod-name: ft-iperf-service-nodeport-host-v4
 spec:

--- a/manifests/svc-nodePort.yaml.j2
+++ b/manifests/svc-nodePort.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ft-http-service-nodeport-pod-v4
+  namespace: {{ namespace }}
   labels:
     pod-name: ft-http-service-nodeport-pod-v4
 spec:
@@ -19,6 +20,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ft-iperf-service-nodeport-pod-v4
+  namespace: {{ namespace }}
   labels:
     pod-name: ft-iperf-service-nodeport-pod-v4
 spec:

--- a/test.sh
+++ b/test.sh
@@ -35,6 +35,7 @@ IPERF_TIME=${IPERF_TIME:-10}
 OVN_TRACE=${OVN_TRACE:-false}
 OVN_TRACE_CMD=${OVN_TRACE_CMD:-./ovnkube-trace -loglevel=5 -tcp}
 FT_HOSTONLY=${FT_HOSTONLY:-unknown}
+FT_NAMESPACE=${FT_NAMESPACE:-default}
 
 # From YAML Files
 CLIENT_POD_NAME_PREFIX=${CLIENT_POD_NAME_PREFIX:-ft-client-pod}
@@ -76,12 +77,12 @@ SSL_ENABLE=${SSL_ENABLE:-"-noSSL"}
 #
 # Query for dynamic data
 #
-SERVER_POD_NODE=`kubectl get pods -o wide | grep $HTTP_SERVER_HOST_POD_NAME  | awk -F' ' '{print $7}'`
+SERVER_POD_NODE=`kubectl get pods -n ${FT_NAMESPACE} -o wide | grep $HTTP_SERVER_HOST_POD_NAME  | awk -F' ' '{print $7}'`
 
-HTTP_SERVER_POD_IP=`kubectl get pods -o wide | grep $HTTP_SERVER_POD_NAME  | awk -F' ' '{print $6}'`
-HTTP_SERVER_HOST_IP=`kubectl get pods -o wide | grep $HTTP_SERVER_HOST_POD_NAME  | awk -F' ' '{print $6}'`
-IPERF_SERVER_POD_IP=`kubectl get pods -o wide | grep $IPERF_SERVER_POD_NAME  | awk -F' ' '{print $6}'`
-IPERF_SERVER_HOST_IP=`kubectl get pods -o wide | grep $IPERF_SERVER_HOST_POD_NAME  | awk -F' ' '{print $6}'`
+HTTP_SERVER_POD_IP=`kubectl get pods -n ${FT_NAMESPACE} -o wide | grep $HTTP_SERVER_POD_NAME  | awk -F' ' '{print $6}'`
+HTTP_SERVER_HOST_IP=`kubectl get pods -n ${FT_NAMESPACE} -o wide | grep $HTTP_SERVER_HOST_POD_NAME  | awk -F' ' '{print $6}'`
+IPERF_SERVER_POD_IP=`kubectl get pods -n ${FT_NAMESPACE} -o wide | grep $IPERF_SERVER_POD_NAME  | awk -F' ' '{print $6}'`
+IPERF_SERVER_HOST_IP=`kubectl get pods -n ${FT_NAMESPACE} -o wide | grep $IPERF_SERVER_HOST_POD_NAME  | awk -F' ' '{print $6}'`
 
 LOCAL_CLIENT_NODE=$SERVER_POD_NODE
 REMOTE_CLIENT_NODE=$LOCAL_CLIENT_NODE
@@ -123,44 +124,44 @@ fi
 
 
 if [ "$FT_HOSTONLY" == false ]; then
-  LOCAL_CLIENT_POD=`kubectl get pods --selector=name=${CLIENT_POD_NAME_PREFIX} -o wide | grep -w "$LOCAL_CLIENT_NODE" | awk -F' ' '{print $1}'`
-  REMOTE_CLIENT_POD=`kubectl get pods --selector=name=${CLIENT_POD_NAME_PREFIX} -o wide| grep -w "$REMOTE_CLIENT_NODE" | awk -F' ' '{print $1}'`
+  LOCAL_CLIENT_POD=`kubectl get pods -n ${FT_NAMESPACE} --selector=name=${CLIENT_POD_NAME_PREFIX} -o wide | grep -w "$LOCAL_CLIENT_NODE" | awk -F' ' '{print $1}'`
+  REMOTE_CLIENT_POD=`kubectl get pods -n ${FT_NAMESPACE} --selector=name=${CLIENT_POD_NAME_PREFIX} -o wide| grep -w "$REMOTE_CLIENT_NODE" | awk -F' ' '{print $1}'`
 else
   LOCAL_CLIENT_POD=
   REMOTE_CLIENT_POD=
 fi
 
-LOCAL_CLIENT_HOST_POD=`kubectl get pods --selector=name=${CLIENT_HOST_POD_NAME_PREFIX} -o wide | grep -w "$LOCAL_CLIENT_NODE" | awk -F' ' '{print $1}'`
-REMOTE_CLIENT_HOST_POD=`kubectl get pods --selector=name=${CLIENT_HOST_POD_NAME_PREFIX} -o wide | grep -w "$REMOTE_CLIENT_NODE" | awk -F' ' '{print $1}'`
+LOCAL_CLIENT_HOST_POD=`kubectl get pods -n ${FT_NAMESPACE} --selector=name=${CLIENT_HOST_POD_NAME_PREFIX} -o wide | grep -w "$LOCAL_CLIENT_NODE" | awk -F' ' '{print $1}'`
+REMOTE_CLIENT_HOST_POD=`kubectl get pods -n ${FT_NAMESPACE} --selector=name=${CLIENT_HOST_POD_NAME_PREFIX} -o wide | grep -w "$REMOTE_CLIENT_NODE" | awk -F' ' '{print $1}'`
 
-HTTP_CLUSTERIP_POD_SVC_IPV4=`kubectl get services | grep $HTTP_CLUSTERIP_POD_SVC_NAME | awk -F' ' '{print $3}'`
-HTTP_CLUSTERIP_POD_SVC_PORT=`kubectl get services | grep $HTTP_CLUSTERIP_POD_SVC_NAME | awk -F' ' '{print $5}' | awk -F/ '{print $1}'`
+HTTP_CLUSTERIP_POD_SVC_IPV4=`kubectl get services -n ${FT_NAMESPACE} | grep $HTTP_CLUSTERIP_POD_SVC_NAME | awk -F' ' '{print $3}'`
+HTTP_CLUSTERIP_POD_SVC_PORT=`kubectl get services -n ${FT_NAMESPACE} | grep $HTTP_CLUSTERIP_POD_SVC_NAME | awk -F' ' '{print $5}' | awk -F/ '{print $1}'`
 
-HTTP_CLUSTERIP_HOST_SVC_IPV4=`kubectl get services | grep $HTTP_CLUSTERIP_HOST_SVC_NAME | awk -F' ' '{print $3}'`
-HTTP_CLUSTERIP_HOST_SVC_PORT=`kubectl get services | grep $HTTP_CLUSTERIP_HOST_SVC_NAME | awk -F' ' '{print $5}' | awk -F/ '{print $1}'`
+HTTP_CLUSTERIP_HOST_SVC_IPV4=`kubectl get services -n ${FT_NAMESPACE} | grep $HTTP_CLUSTERIP_HOST_SVC_NAME | awk -F' ' '{print $3}'`
+HTTP_CLUSTERIP_HOST_SVC_PORT=`kubectl get services -n ${FT_NAMESPACE} | grep $HTTP_CLUSTERIP_HOST_SVC_NAME | awk -F' ' '{print $5}' | awk -F/ '{print $1}'`
 
-HTTP_NODEPORT_POD_SVC_IPV4=`kubectl get services | grep $HTTP_NODEPORT_SVC_NAME | awk -F' ' '{print $3}'`
-HTTP_NODEPORT_POD_SVC_PORT=`kubectl get services | grep $HTTP_NODEPORT_SVC_NAME | awk -F' ' '{print $5}' | awk -F: '{print $2}' | awk -F'/' '{print $1}'`
+HTTP_NODEPORT_POD_SVC_IPV4=`kubectl get services -n ${FT_NAMESPACE} | grep $HTTP_NODEPORT_SVC_NAME | awk -F' ' '{print $3}'`
+HTTP_NODEPORT_POD_SVC_PORT=`kubectl get services -n ${FT_NAMESPACE} | grep $HTTP_NODEPORT_SVC_NAME | awk -F' ' '{print $5}' | awk -F: '{print $2}' | awk -F'/' '{print $1}'`
 
-HTTP_NODEPORT_HOST_SVC_IPV4=`kubectl get services | grep $HTTP_NODEPORT_HOST_SVC_NAME | awk -F' ' '{print $3}'`
-HTTP_NODEPORT_HOST_SVC_PORT=`kubectl get services | grep $HTTP_NODEPORT_HOST_SVC_NAME | awk -F' ' '{print $5}' | awk -F: '{print $2}' | awk -F'/' '{print $1}'`
+HTTP_NODEPORT_HOST_SVC_IPV4=`kubectl get services -n ${FT_NAMESPACE} | grep $HTTP_NODEPORT_HOST_SVC_NAME | awk -F' ' '{print $3}'`
+HTTP_NODEPORT_HOST_SVC_PORT=`kubectl get services -n ${FT_NAMESPACE} | grep $HTTP_NODEPORT_HOST_SVC_NAME | awk -F' ' '{print $5}' | awk -F: '{print $2}' | awk -F'/' '{print $1}'`
 
-IPERF_CLUSTERIP_POD_SVC_IPV4=`kubectl get services | grep $IPERF_CLUSTERIP_POD_SVC_NAME | awk -F' ' '{print $3}'`
-IPERF_CLUSTERIP_POD_SVC_PORT=`kubectl get services | grep $IPERF_CLUSTERIP_POD_SVC_NAME | awk -F' ' '{print $5}' | awk -F'/' '{print $1}'`
+IPERF_CLUSTERIP_POD_SVC_IPV4=`kubectl get services -n ${FT_NAMESPACE} | grep $IPERF_CLUSTERIP_POD_SVC_NAME | awk -F' ' '{print $3}'`
+IPERF_CLUSTERIP_POD_SVC_PORT=`kubectl get services -n ${FT_NAMESPACE} | grep $IPERF_CLUSTERIP_POD_SVC_NAME | awk -F' ' '{print $5}' | awk -F'/' '{print $1}'`
 
-IPERF_CLUSTERIP_HOST_SVC_IPV4=`kubectl get services | grep $IPERF_CLUSTERIP_HOST_SVC_NAME | awk -F' ' '{print $3}'`
-IPERF_CLUSTERIP_HOST_SVC_PORT=`kubectl get services | grep $IPERF_CLUSTERIP_HOST_SVC_NAME | awk -F' ' '{print $5}' | awk -F'/' '{print $1}'`
+IPERF_CLUSTERIP_HOST_SVC_IPV4=`kubectl get services -n ${FT_NAMESPACE} | grep $IPERF_CLUSTERIP_HOST_SVC_NAME | awk -F' ' '{print $3}'`
+IPERF_CLUSTERIP_HOST_SVC_PORT=`kubectl get services -n ${FT_NAMESPACE} | grep $IPERF_CLUSTERIP_HOST_SVC_NAME | awk -F' ' '{print $5}' | awk -F'/' '{print $1}'`
 
-IPERF_NODEPORT_POD_SVC_IPV4=`kubectl get services | grep $IPERF_NODEPORT_POD_SVC_NAME | awk -F' ' '{print $3}'`
-IPERF_NODEPORT_POD_SVC_PORT=`kubectl get services | grep $IPERF_NODEPORT_POD_SVC_NAME | awk -F' ' '{print $5}' | awk -F: '{print $2}' | awk -F'/' '{print $1}'`
+IPERF_NODEPORT_POD_SVC_IPV4=`kubectl get services -n ${FT_NAMESPACE} | grep $IPERF_NODEPORT_POD_SVC_NAME | awk -F' ' '{print $3}'`
+IPERF_NODEPORT_POD_SVC_PORT=`kubectl get services -n ${FT_NAMESPACE} | grep $IPERF_NODEPORT_POD_SVC_NAME | awk -F' ' '{print $5}' | awk -F: '{print $2}' | awk -F'/' '{print $1}'`
 
-IPERF_NODEPORT_HOST_SVC_IPV4=`kubectl get services | grep $IPERF_NODEPORT_HOST_SVC_NAME | awk -F' ' '{print $3}'`
-IPERF_NODEPORT_HOST_SVC_PORT=`kubectl get services | grep $IPERF_NODEPORT_HOST_SVC_NAME | awk -F' ' '{print $5}' | awk -F: '{print $2}' | awk -F'/' '{print $1}'`
+IPERF_NODEPORT_HOST_SVC_IPV4=`kubectl get services -n ${FT_NAMESPACE} | grep $IPERF_NODEPORT_HOST_SVC_NAME | awk -F' ' '{print $3}'`
+IPERF_NODEPORT_HOST_SVC_PORT=`kubectl get services -n ${FT_NAMESPACE} | grep $IPERF_NODEPORT_HOST_SVC_NAME | awk -F' ' '{print $5}' | awk -F: '{print $2}' | awk -F'/' '{print $1}'`
 
 
 # NOTE: env in the container has values that could be used instead of using the above commands:
 #
-# kubectl exec -it $LOCAL_CLIENT_POD -- env
+# kubectl exec -it -n ${FT_NAMESPACE} $LOCAL_CLIENT_POD -- env
 #  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 #  HOSTNAME=ft-client-w2rps
 #  container=docker
@@ -181,7 +182,7 @@ IPERF_NODEPORT_HOST_SVC_PORT=`kubectl get services | grep $IPERF_NODEPORT_HOST_S
 #  KUBERNETES_PORT=tcp://10.96.0.1:443
 #  KUBERNETES_PORT_443_TCP_PORT=443
 #
-# kubectl exec -it $LOCAL_CLIENT_POD -- /bin/sh -c 'curl "http://$MY_WEB_SERVICE_NODE_V4_SERVICE_HOST:$MY_WEB_SERVICE_NODE_V4_SERVICE_PORT/"'
+# kubectl exec -it -n ${FT_NAMESPACE} $LOCAL_CLIENT_POD -- /bin/sh -c 'curl "http://$MY_WEB_SERVICE_NODE_V4_SERVICE_HOST:$MY_WEB_SERVICE_NODE_V4_SERVICE_PORT/"'
 
 
 #
@@ -197,6 +198,7 @@ dump-working-data() {
   echo "    FT_VARS                            $FT_VARS"
   echo "    FT_NOTES                           $FT_NOTES"
   echo "    FT_HOSTONLY                        $FT_HOSTONLY"
+  echo "    FT_NAMESPACE                       $FT_NAMESPACE"
   echo "    CURL                               $CURL"
   echo "    CURL_CMD                           $CURL_CMD"
   echo "    IPERF                              $IPERF"
@@ -287,12 +289,12 @@ process-curl() {
     TMP_OUTPUT=`$CURL_CMD "http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/"`
   elif [ -z "${TEST_SERVER_HTTP_DST_PORT}" ]; then
     # No Port, so leave off Port from command
-    echo "kubectl exec -it ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}/\""
-    TMP_OUTPUT=`kubectl exec -it ${TEST_CLIENT_POD} -- $CURL_CMD "http://${TEST_SERVER_HTTP_DST}/"`
+    echo "kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}/\""
+    TMP_OUTPUT=`kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD "http://${TEST_SERVER_HTTP_DST}/"`
   else
     # Default command
-    echo "kubectl exec -it ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/\""
-    TMP_OUTPUT=`kubectl exec -it ${TEST_CLIENT_POD} -- $CURL_CMD "http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/"`
+    echo "kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/\""
+    TMP_OUTPUT=`kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD "http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/"`
   fi
 
   # Dump command output
@@ -313,8 +315,8 @@ process-iperf() {
 
   IPERF_FILENAME="${IPERF_LOGS_DIR}/${TEST_FILENAME}"
 
-  echo "kubectl exec -it $TEST_CLIENT_POD -- $IPERF_CMD -c $TEST_SERVER_IPERF_DST -p $TEST_SERVER_IPERF_DST_PORT -t $IPERF_TIME"
-  kubectl exec -it $TEST_CLIENT_POD -- $IPERF_CMD -c $TEST_SERVER_IPERF_DST -p $TEST_SERVER_IPERF_DST_PORT -t $IPERF_TIME  > ${IPERF_FILENAME}
+  echo "kubectl exec -it -n ${FT_NAMESPACE} $TEST_CLIENT_POD -- $IPERF_CMD -c $TEST_SERVER_IPERF_DST -p $TEST_SERVER_IPERF_DST_PORT -t $IPERF_TIME"
+  kubectl exec -it -n ${FT_NAMESPACE} $TEST_CLIENT_POD -- $IPERF_CMD -c $TEST_SERVER_IPERF_DST -p $TEST_SERVER_IPERF_DST_PORT -t $IPERF_TIME  > ${IPERF_FILENAME}
 
   # Dump command output
   if [ "$VERBOSE" == true ]; then
@@ -412,6 +414,14 @@ if [ ! -z "$1" ] ; then
     echo "  FT_REQ_SERVER_NODE         - Node to run server pods on. Must be set before launching"
     echo "                               pods. Example:"
     echo "                                 FT_REQ_SERVER_NODE=ovn-worker3 ./launch.sh"
+    echo "  FT_NAMESPACE               - Namespace for all pods, configMaps and services associated with"
+    echo "                               Flow Tester. Defaults to \"default\" namespace. It is best to"
+    echo "                               export this variable because launch.sh and cleanup.sh also need"
+    echo "                               the same value set. Example:"
+    echo "                                 export FT_NAMESPACE=flow-test"
+    echo "                                 ./launch.sh"
+    echo "                                 ./test.sh"
+    echo "                                 ./cleanup.sh"
 
     dump-working-data
   else
@@ -1208,7 +1218,7 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 11 ] && [ "$FT_HOSTONLY" == false 
     process-curl
     #if [ "$FT_NOTES" == true ]; then
     #  echo "curl SvcName:NODEPORT"
-    #  echo "kubectl exec -it ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/\""
+    #  echo "kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/\""
     #  echo -e "${BLUE}curl: (6) Could not resolve host: ft-http-service-node-v4; Unknown error${NC}"
     #  echo -e "${BLUE}Should this work?${NC}"
     #  echo
@@ -1262,7 +1272,7 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 12 ]; then
     process-curl
     #if [ "$FT_NOTES" == true ]; then
     #  echo "curl SvcName:NODEPORT"
-    #  echo "kubectl exec -it ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/\""
+    #  echo "kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/\""
     #  echo -e "${BLUE}Test Skipped - the host has no idea about svc DNS resolution${NC}"
     #  echo
     #fi
@@ -1315,7 +1325,7 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 12 ]; then
     process-curl
     #if [ "$FT_NOTES" == true ]; then
     #  echo "curl SvcName:NODEPORT"
-    #  echo "kubectl exec -it ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/\""
+    #  echo "kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/\""
     #  echo -e "${BLUE}Test Skipped - the host has no idea about svc DNS resolution${NC}"
     #  echo
     #fi


### PR DESCRIPTION
There was one yaml that had namespace hardocded to "default" and the
rest had nothing. A bug was reported where "project" was set to
something other than "default", so all objects were created in the
"project" namespace except the one hardcoded. Made namespace a variable
so it can be overwritten, but defaults to "default".

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>