### PR TITLE
Fix cmd of getting kubernetes API endpoint port

### DIFF
--- a/mctest.sh
+++ b/mctest.sh
@@ -17,6 +17,7 @@ FT_NAMESPACE=${FT_NAMESPACE:-flow-test}
 FT_SVC_QUALIFIER=${FT_SVC_QUALIFIER:-".${FT_NAMESPACE}.svc.clusterset.local"}
 HTTP_SERVER_HOST_POD_NAME=${HTTP_SERVER_HOST_POD_NAME:-ft-http-server-host-v4}
 
+ORIG_CONTEXT=$(kubectl config current-context)
 
 # Retrieve all the managed clusters
 CLUSTER_ARRAY=($(kubectl config get-contexts --no-headers=true | awk -F' ' '{print $3}'))
@@ -42,3 +43,5 @@ do
       echo "  Flow-Test not deployed on Cluster ${CLUSTER_ARRAY[$i]}"
     fi
 done
+
+kubectl config use-context ${ORIG_CONTEXT}


### PR DESCRIPTION
Rework #29 to handle both one IP address and multiple IP addresses. #29 only fixed the multiple IP case.

While in the code, fixed a few other things:
* There were several places that the script called the same `kubectl` command
  multiple times in a row. Updated to call once and save output, then parse
  the output multiple ways using.
* Replaced `VAR='<commmand>'` to `VAR=$(<commmand>)` based on review of patch
  in Submariner.
* Preserve the current context when running mctest.sh.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>