### PR TITLE
Add Hardware Offload Validation as a test option for flows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,9 +308,9 @@ This script uses ENV Variables to control test. Here are few key ones:
                                  VERBOSE=true ./test.sh
   IPERF                      - 'iperf3' can be run on each flow, off by default. Example:
                                  IPERF=true ./test.sh
-  HWOL                       - Hardware Offload Validation can be run on each applicable flow."
-                               Parameters from IPERF will be used to generate traffic. Example:"
-                                 HWOL=true ./test.sh"
+  HWOL                       - Hardware Offload Validation can be run on each applicable flow.
+                               Parameters from IPERF will be used to generate traffic. Example:
+                                 HWOL=true ./test.sh
   OVN_TRACE                  - 'ovn-trace' can be run on each flow, off by deafult. Example:
                                  OVN_TRACE=true ./test.sh
   FT_VARS                    - Print script variables. Off by default. Example:
@@ -429,101 +429,155 @@ To run all the tests, simply run the script.
 $ FT_VARS=true ./test.sh
 
 Default/Override Values:
+  Launch Control:
+    FT_HOSTONLY                        false
+    FT_CLIENTONLY                      false
+    FT_NAMESPACE                       default
+    FT_REQ_SERVER_NODE                 all
+    FT_REQ_REMOTE_CLIENT_NODE          first
+    FT_SRIOV_NODE_LABEL                network.operator.openshift.io/external-openvswitch
+    FT_EXPORT_SVC                      false
+  Label Management:
+    FT_SERVER_NODE_LABEL               ft.ServerPod
+    FT_CLIENT_NODE_LABEL               ft.ClientPod
   Test Control:
     TEST_CASE (0 means all)            1
     VERBOSE                            false
     FT_VARS                            true
     FT_NOTES                           true
+    FT_DEBUG                           false
     CURL                               true
     CURL_CMD                           curl -m 5
-    IPERF                              true
+    IPERF                              false
     IPERF_CMD                          iperf3
-    IPERF_TIME                         2
+    IPERF_TIME                         10
     IPERF_FORWARD_TEST_OPT
     IPERF_REVERSE_TEST_OPT             -R
+    FT_CLIENT_CPU_MASK
     OVN_TRACE                          false
     OVN_TRACE_CMD                      ./ovnkube-trace -loglevel=5 -tcp
-    FT_REQ_REMOTE_CLIENT_NODE          first
+    FT_SVC_QUALIFIER
+    FT_MC_NAMESPACE                    submariner-operator
+    FT_MC_CO_SERVER_LABEL              submariner.io/gateway=true
   OVN Trace Control:
     OVN_K_NAMESPACE                    ovn-kubernetes
     SSL_ENABLE                         -noSSL
   From YAML Files:
+    NET_ATTACH_DEF_NAME                ftnetattach
+    SRIOV_RESOURCE_NAME                openshift.io/mlnx_bf
+    TEST_IMAGE                         quay.io/billy99/ft-base-image:0.9
     CLIENT_POD_NAME_PREFIX             ft-client-pod
     http Server:
       HTTP_SERVER_POD_NAME             ft-http-server-pod-v4
       HTTP_SERVER_HOST_POD_NAME        ft-http-server-host-v4
       HTTP_CLUSTERIP_POD_SVC_NAME      ft-http-service-clusterip-pod-v4
+      HTTP_CLUSTERIP_POD_SVC_PORT      8080
       HTTP_CLUSTERIP_HOST_SVC_NAME     ft-http-service-clusterip-host-v4
+      HTTP_CLUSTERIP_HOST_SVC_PORT     8079
       HTTP_NODEPORT_SVC_NAME           ft-http-service-nodeport-pod-v4
+      HTTP_NODEPORT_POD_SVC_PORT       30080
       HTTP_NODEPORT_HOST_SVC_NAME      ft-http-service-nodeport-host-v4
+      HTTP_NODEPORT_HOST_SVC_PORT      30079
     iperf Server:
       IPERF_SERVER_POD_NAME            ft-iperf-server-pod-v4
       IPERF_SERVER_HOST_POD_NAME       ft-iperf-server-host-v4
       IPERF_CLUSTERIP_POD_SVC_NAME     ft-iperf-service-clusterip-pod-v4
+      IPERF_CLUSTERIP_POD_SVC_PORT     5201
       IPERF_CLUSTERIP_HOST_SVC_NAME    ft-iperf-service-clusterip-host-v4
+      IPERF_CLUSTERIP_HOST_SVC_PORT    5202
       IPERF_NODEPORT_POD_SVC_NAME      ft-iperf-service-nodeport-pod-v4
+      IPERF_NODEPORT_POD_SVC_PORT      30201
       IPERF_NODEPORT_HOST_SVC_NAME     ft-iperf-service-nodeport-host-v4
+      IPERF_NODEPORT_HOST_SVC_PORT     30202
+    SERVER_PATH                        /etc/httpserver/
     POD_SERVER_STRING                  Server - Pod Backend Reached
     HOST_SERVER_STRING                 Server - Host Backend Reached
     EXTERNAL_SERVER_STRING             The document has moved
+    KUBEAPI_SERVER_STRING              serverAddressByClientCIDRs
   External Access:
     EXTERNAL_IP                        8.8.8.8
     EXTERNAL_URL                       google.com
 Queried Values:
   Pod Backed:
-    HTTP_SERVER_POD_IP                 10.244.2.29
-    IPERF_SERVER_POD_IP                10.244.2.30
-    SERVER_POD_NODE                    ovn-worker3
-    LOCAL_CLIENT_NODE                  ovn-worker3
-    LOCAL_CLIENT_POD                   ft-client-pod-76qlj
-    REMOTE_CLIENT_NODE_LIST             ovn-worker4
-    REMOTE_CLIENT_POD_LIST             ft-client-pod-566xj
-    HTTP_CLUSTERIP_POD_SVC_IPV4        10.96.39.137
+    HTTP_SERVER_POD_IP                 10.131.1.66
+    IPERF_SERVER_POD_IP                10.131.1.67
+    SERVER_POD_NODE                    worker-advnetlab26
+    LOCAL_CLIENT_NODE                  worker-advnetlab26
+    LOCAL_CLIENT_POD                   ft-client-pod-sriov-x2xd7
+    REMOTE_CLIENT_NODE_LIST            worker-advnetlab27
+    REMOTE_CLIENT_POD_LIST             ft-client-pod-sriov-p9z2j
+    HTTP_CLUSTERIP_POD_SVC_IPV4_LIST   172.30.92.190
     HTTP_CLUSTERIP_POD_SVC_PORT        8080
-    HTTP_NODEPORT_POD_SVC_IPV4         10.96.28.182
+    HTTP_NODEPORT_POD_SVC_IPV4_LIST    172.30.65.201
     HTTP_NODEPORT_POD_SVC_PORT         30080
-    IPERF_CLUSTERIP_POD_SVC_IPV4       10.96.153.56
+    IPERF_CLUSTERIP_POD_SVC_IPV4_LIST  172.30.164.182
     IPERF_CLUSTERIP_POD_SVC_PORT       5201
-    IPERF_NODEPORT_POD_SVC_IPV4        10.96.37.54
+    IPERF_NODEPORT_POD_SVC_IPV4_LIST   172.30.118.3
     IPERF_NODEPORT_POD_SVC_PORT        30201
   Host backed:
-    HTTP_SERVER_HOST_IP                172.18.0.5
-    IPERF_SERVER_HOST_IP               172.18.0.5
-    SERVER_HOST_NODE                   ovn-worker3
-    LOCAL_CLIENT_HOST_NODE             ovn-worker3
-    LOCAL_CLIENT_HOST_POD              ft-client-pod-host-kttz2
-    REMOTE_CLIENT_HOST_NODE_LIST       ovn-worker4
-    REMOTE_CLIENT_HOST_POD_LIST        ft-client-pod-host-hp5r2
-    HTTP_CLUSTERIP_HOST_SVC_IPV4       10.96.21.56
-    HTTP_CLUSTERIP_HOST_SVC_PORT       8081
-    HTTP_NODEPORT_HOST_SVC_IPV4        10.96.252.33
-    HTTP_NODEPORT_HOST_SVC_PORT        30081
-    IPERF_CLUSTERIP_HOST_SVC_IPV4      10.96.11.170
+    HTTP_SERVER_HOST_IP                192.168.111.33
+    IPERF_SERVER_HOST_IP               192.168.111.33
+    SERVER_HOST_NODE                   worker-advnetlab26
+    LOCAL_CLIENT_HOST_NODE             worker-advnetlab26
+    LOCAL_CLIENT_HOST_POD              ft-client-pod-host-xvhd5
+    REMOTE_CLIENT_HOST_NODE_LIST       worker-advnetlab27
+    REMOTE_CLIENT_HOST_POD_LIST        ft-client-pod-host-tc9h6
+    HTTP_CLUSTERIP_HOST_SVC_IPV4_LIST  172.30.4.237
+    HTTP_CLUSTERIP_HOST_SVC_PORT       8079
+    HTTP_NODEPORT_HOST_SVC_IPV4_LIST   172.30.232.255
+    HTTP_NODEPORT_HOST_SVC_PORT        30079
+    IPERF_CLUSTERIP_HOST_SVC_IPV4_LIST 172.30.203.69
     IPERF_CLUSTERIP_HOST_SVC_PORT      5202
-    IPERF_NODEPORT_HOST_SVC_IPV4       10.96.154.57
+    IPERF_NODEPORT_HOST_SVC_IPV4_LIST  172.30.48.14
     IPERF_NODEPORT_HOST_SVC_PORT       30202
+  Kubernetes API:
+    HTTP_CLUSTERIP_KUBEAPI_SVC_IPV4    172.30.0.1
+    HTTP_CLUSTERIP_KUBEAPI_SVC_PORT    443
+    HTTP_CLUSTERIP_KUBEAPI_EP_IP       192.168.111.20
+    HTTP_CLUSTERIP_KUBEAPI_EP_PORT     6443
+    HTTP_CLUSTERIP_KUBEAPI_SVC_NAME    kubernetes.default.svc
 
 
-FLOW 01: Typical Pod to Pod traffic (using cluster subnet)
-----------------------------------------------------------
+
+FLOW 01: Pod to Pod traffic
+---------------------------
 
 *** 1-a: Pod to Pod (Same Node) ***
 
-kubectl exec -it ft-client-pod-76qlj -- curl -m 5 "http://10.244.2.29:8080/"
+=== CURL ===
+admin:worker-advnetlab26 -> admin:worker-advnetlab26
+kubectl exec -n default ft-client-pod-sriov-x2xd7 -- curl -m 5 "http://10.131.1.66:8080/etc/httpserver/"
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   164  100   164    0     0    404      0 --:--:-- --:--:-- --:--:--   403
+
 SUCCESS
 
 
 *** 1-b: Pod to Pod (Different Node) ***
-kubectl exec -it ft-client-pod-566xj -- curl -m 5 "http://10.244.2.29:8080/"
+
+=== CURL ===
+admin:worker-advnetlab27 -> admin:worker-advnetlab26
+kubectl exec -n default ft-client-pod-sriov-p9z2j -- curl -m 5 "http://10.131.1.66:8080/etc/httpserver/"
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   164  100   164    0     0    471      0 --:--:-- --:--:-- --:--:--   472
+
 SUCCESS
 
 
 FLOW 02: Pod -> Cluster IP Service traffic
 ------------------------------------------
 
-*** 2-a: Pod -> Cluster IP Service traffic (Same Node) ***
+*** 2-a: Pod to Host (Same Node) ***
 
-kubectl exec -it ft-client-pod-2twqq -- curl -m 5 "http://10.96.145.26:8080/"
+=== CURL ===
+admin:worker-advnetlab26 -> admin:worker-advnetlab26
+kubectl exec -n default ft-client-pod-sriov-x2xd7 -- curl -m 5 "http://192.168.111.33:8079/etc/httpserver/"
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   170  100   170    0     0    740      0 --:--:-- --:--:-- --:--:--   739
+
 SUCCESS
 
 :
@@ -585,19 +639,32 @@ is working. `curl` is enabled by default, but can be disabled using
 ```
 $ TEST_CASE=1 ./test.sh
 
-FLOW 01: Typical Pod to Pod traffic (using cluster subnet)
-----------------------------------------------------------
+FLOW 01: Pod to Pod traffic
+---------------------------
 
 *** 1-a: Pod to Pod (Same Node) ***
 
-kubectl exec -it ft-client-pod-2twqq -- curl -m 5 "http://10.244.2.26:8080/"
+=== CURL ===
+admin:worker-advnetlab26 -> admin:worker-advnetlab26
+kubectl exec -n default ft-client-pod-sriov-x2xd7 -- curl -m 5 "http://10.131.1.66:8080/etc/httpserver/"
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   164  100   164    0     0    420      0 --:--:-- --:--:-- --:--:--   419
+
 SUCCESS
 
 
 *** 1-b: Pod to Pod (Different Node) ***
 
-kubectl exec -it ft-client-pod-gc6dw -- curl -m 5 "http://10.244.2.26:8080/"
+=== CURL ===
+admin:worker-advnetlab27 -> admin:worker-advnetlab26
+kubectl exec -n default ft-client-pod-sriov-p9z2j -- curl -m 5 "http://10.131.1.66:8080/etc/httpserver/"
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   164  100   164    0     0    567      0 --:--:-- --:--:-- --:--:--   569
+
 SUCCESS
+
 ```
 
 ### iperf3
@@ -605,7 +672,7 @@ SUCCESS
 `iperf3` is used to test packet throughput. It can be used to determine
 the rough throughput of each flow. When enabled, `iperf3` is run and a
 summary of the results is printed. Both forward and reverse directions
-of traffic is tested. Traffic is first sent from client, then traffic
+of traffic are tested. Traffic is first sent from client, then traffic
 is sent from server (reverse option in `iperf3`).
 
 ```
@@ -616,54 +683,38 @@ FLOW 01: Pod to Pod traffic
 
 *** 1-a: Pod to Pod (Same Node) ***
 
-admin:worker-advnetlab48 -> admin:worker-advnetlab48
-kubectl exec -n default ft-client-pod-sriov-7c7kw -- curl -m 5 "http://10.131.0.7:8080/etc/httpserver/"
+=== CURL ===
+admin:worker-advnetlab26 -> admin:worker-advnetlab26
+kubectl exec -n default ft-client-pod-sriov-x2xd7 -- curl -m 5 "http://10.131.1.66:8080/etc/httpserver/"
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
+100   164  100   164    0     0    419      0 --:--:-- --:--:-- --:--:--   420
 
-  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
-100   164  100   164    0     0    501      0 --:--:-- --:--:-- --:--:--   501
-100   164  100   164    0     0    501      0 --:--:-- --:--:-- --:--:--   501
 SUCCESS
 
-admin:worker-advnetlab48 -> admin:worker-advnetlab48
-kubectl exec -n default ft-client-pod-sriov-7c7kw --  iperf3 -c 10.131.0.8 -p 5201 -t 30
-admin:worker-advnetlab48 -(Reverse)-> admin:worker-advnetlab48
-kubectl exec -n default ft-client-pod-sriov-7c7kw --  iperf3 -R -c 10.131.0.8 -p 5201 -t 30
-Summary (see iperf-logs/01-a-pod2pod-sameNode.txt for full detail):
+=== IPERF ===
+== admin:worker-advnetlab26 -> admin:worker-advnetlab26 ==
+kubectl exec -n default ft-client-pod-sriov-x2xd7 --  iperf3  -c 10.131.1.67 -p 5201 -t 2
+Summary (see iperf-logs/01-a-client-server-pod2pod-sameNode.txt for full detail):
 [ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-30.00  sec  96.8 GBytes  27.7 Gbits/sec  14601             sender
-[  5]   0.00-30.00  sec  96.8 GBytes  27.7 Gbits/sec                  receiver
---
+[  5]   0.00-2.00   sec  5.62 GBytes  24.1 Gbits/sec  947             sender
+[  5]   0.00-2.00   sec  5.62 GBytes  24.1 Gbits/sec                  receiver
+
+SUCCESS
+
+== admin:worker-advnetlab26 -> admin:worker-advnetlab26 (Reverse) ==
+kubectl exec -n default ft-client-pod-sriov-x2xd7 --  iperf3 -R -c 10.131.1.67 -p 5201 -t 2
+Summary (see iperf-logs/01-a-server-client-pod2pod-sameNode.txt for full detail):
 [ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-30.00  sec  95.0 GBytes  27.2 Gbits/sec  16500             sender
-[  5]   0.00-30.00  sec  95.0 GBytes  27.2 Gbits/sec                  receiver
+[  5]   0.00-2.00   sec  6.29 GBytes  27.0 Gbits/sec  2187             sender
+[  5]   0.00-2.00   sec  6.29 GBytes  27.0 Gbits/sec                  receiver
+
 SUCCESS
 
 
 *** 1-b: Pod to Pod (Different Node) ***
 
-admin:worker-advnetlab49 -> admin:worker-advnetlab48
-kubectl exec -n default ft-client-pod-sriov-5g7s5 -- curl -m 5 "http://10.131.0.7:8080/etc/httpserver/"
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
-100   164  100   164    0     0    383      0 --:--:-- --:--:-- --:--:--   384
-SUCCESS
-
-admin:worker-advnetlab49 -> admin:worker-advnetlab48
-kubectl exec -n default ft-client-pod-sriov-5g7s5 --  iperf3 -c 10.131.0.8 -p 5201 -t 30
-admin:worker-advnetlab49 -(Reverse)-> admin:worker-advnetlab48
-kubectl exec -n default ft-client-pod-sriov-5g7s5 --  iperf3 -R -c 10.131.0.8 -p 5201 -t 30
-Summary (see iperf-logs/01-b-pod2pod-diffNode.txt for full detail):
-[ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-30.00  sec  64.6 GBytes  18.5 Gbits/sec  3767             sender
-[  5]   0.00-30.00  sec  64.6 GBytes  18.5 Gbits/sec                  receiver
---
-[ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-30.00  sec  71.8 GBytes  20.6 Gbits/sec  3763             sender
-[  5]   0.00-30.00  sec  71.8 GBytes  20.5 Gbits/sec                  receiver
-SUCCESS
+:
 ```
 
 When `iperf3` is run on each sub-flow, the full output of the command is piped to
@@ -671,35 +722,59 @@ files in the `iperf-logs/` directory. Use `VERBOSE=true` to when command is exec
 to see full output command is run. Below is a list of sample output files:
 
 ```
-$ ls -al iperf-logs/
-total 200
-drwxr-xr-x. 2 root root 4096 Jun  9 11:59 .
-drwxr-xr-x. 9 root root 4096 Jun  9 10:27 ..
--rw-r--r--. 1 root root 5438 Jun  9 10:28 01-a-pod2pod-sameNode.txt
--rw-r--r--. 1 root root 5435 Jun  9 10:33 01-b-pod2pod-diffNode.txt
--rw-r--r--. 1 root root 5458 Jun  9 10:38 02-a-pod2host-sameNode.txt
--rw-r--r--. 1 root root 5455 Jun  9 10:39 02-b-pod2host-diffNode.txt
--rw-r--r--. 1 root root 5454 Jun  9 10:40 03-a-pod2clusterIpSvc-podBackend-sameNode.txt
--rw-r--r--. 1 root root 5450 Jun  9 10:45 03-b-pod2clusterIpSvc-podBackend-diffNode.txt
--rw-r--r--. 1 root root 5448 Jun  9 10:51 04-a-pod2clusterIpSvc-hostBackend-sameNode.txt
--rw-r--r--. 1 root root 5445 Jun  9 10:56 04-b-pod2clusterIpSvc-hostBackend-diffNode.txt
--rw-r--r--. 1 root root 5463 Jun  9 11:01 05-a-pod2nodePortSvc-podBackend-sameNode.txt
--rw-r--r--. 1 root root 5459 Jun  9 11:06 05-b-pod2nodePortSvc-podBackend-diffNode.txt
--rw-r--r--. 1 root root 5461 Jun  9 11:11 06-a-pod2nodePortSvc-hostBackend-sameNode.txt
--rw-r--r--. 1 root root 5459 Jun  9 11:16 06-b-pod2nodePortSvc-hostBackend-diffNode.txt
--rw-r--r--. 1 root root 5458 Jun  9 11:21 07-a-host2pod-sameNode.txt
--rw-r--r--. 1 root root 5434 Jun  9 11:22 07-b-host2pod-diffNode.txt
--rw-r--r--. 1 root root 5461 Jun  9 11:23 08-a-host2host-sameNode.txt
--rw-r--r--. 1 root root 5464 Jun  9 11:24 08-b-host2host-diffNode.txt
--rw-r--r--. 1 root root 5457 Jun  9 11:25 09-a-host2clusterIpSvc-podBackend-sameNode.txt
--rw-r--r--. 1 root root 5457 Jun  9 11:30 09-b-host2clusterIpSvc-podBackend-diffNode.txt
--rw-r--r--. 1 root root 5456 Jun  9 11:36 10-a-host2clusterIpSvc-hostBackend-sameNode.txt
--rw-r--r--. 1 root root 5452 Jun  9 11:41 10-b-host2clusterIpSvc-hostBackend-diffNode.txt
--rw-r--r--. 1 root root 5466 Jun  9 11:46 11-a-host2nodePortSvc-podBackend-sameNode.txt
--rw-r--r--. 1 root root 5468 Jun  9 11:51 11-b-host2nodePortSvc-podBackend-diffNode.txt
--rw-r--r--. 1 root root 5407 Jun  9 11:56 12-a-host2nodePortSvc-hostBackend-sameNode.txt
--rw-r--r--. 1 root root 2753 Jun  9 12:00 12-b-host2nodePortSvc-hostBackend-diffNode.txt
--rw-r--r--. 1 root root   70 Jun  9 10:27 .gitignore
+$ ls -la
+total 204
+drwxr-xr-x. 2 root root 4096 Jun 27 17:09 .
+drwxr-xr-x. 9 root root 4096 Jun 27 15:36 ..
+-rw-r--r--. 1 root root 2833 Jun 27 15:37 01-a-client-server-pod2pod-sameNode.txt
+-rw-r--r--. 1 root root 2617 Jun 27 15:38 01-a-server-client-pod2pod-sameNode.txt
+-rw-r--r--. 1 root root 2826 Jun 27 15:42 01-b-client-server-pod2pod-diffNode.txt
+-rw-r--r--. 1 root root 2616 Jun 27 15:43 01-b-server-client-pod2pod-diffNode.txt
+-rw-r--r--. 1 root root 2833 Jun 27 15:47 02-a-client-server-pod2host-sameNode.txt
+-rw-r--r--. 1 root root 2626 Jun 27 15:48 02-a-server-client-pod2host-sameNode.txt
+-rw-r--r--. 1 root root 2832 Jun 27 15:48 02-b-client-server-pod2host-diffNode.txt
+-rw-r--r--. 1 root root 2625 Jun 27 15:49 02-b-server-client-pod2host-diffNode.txt
+-rw-r--r--. 1 root root 2837 Jun 27 15:50 03-a-client-server-pod2clusterIpSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root 2626 Jun 27 15:50 03-a-server-client-pod2clusterIpSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root 2832 Jun 27 15:55 03-b-client-server-pod2clusterIpSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root 2625 Jun 27 15:55 03-b-server-client-pod2clusterIpSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root 2831 Jun 27 16:00 04-a-client-server-pod2clusterIpSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root 2623 Jun 27 16:00 04-a-server-client-pod2clusterIpSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root 2829 Jun 27 16:05 04-b-client-server-pod2clusterIpSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root 2622 Jun 27 16:05 04-b-server-client-pod2clusterIpSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root 2839 Jun 27 16:10 05-a-client-server-pod2nodePortSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root 2628 Jun 27 16:10 05-a-server-client-pod2nodePortSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root 2834 Jun 27 16:15 05-b-client-server-pod2nodePortSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root 2627 Jun 27 16:16 05-b-server-client-pod2nodePortSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root 2835 Jun 27 16:20 06-a-client-server-pod2nodePortSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root 2628 Jun 27 16:21 06-a-server-client-pod2nodePortSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root 2835 Jun 27 16:25 06-b-client-server-pod2nodePortSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root 2627 Jun 27 16:26 06-b-server-client-pod2nodePortSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root 2826 Jun 27 16:30 07-a-client-server-host2pod-sameNode.txt
+-rw-r--r--. 1 root root 2615 Jun 27 16:31 07-a-server-client-host2pod-sameNode.txt
+-rw-r--r--. 1 root root 2824 Jun 27 16:31 07-b-client-server-host2pod-diffNode.txt
+-rw-r--r--. 1 root root 2615 Jun 27 16:32 07-b-server-client-host2pod-diffNode.txt
+-rw-r--r--. 1 root root 2834 Jun 27 16:32 08-a-client-server-host2host-sameNode.txt
+-rw-r--r--. 1 root root 2627 Jun 27 16:33 08-a-server-client-host2host-sameNode.txt
+-rw-r--r--. 1 root root 2835 Jun 27 16:33 08-b-client-server-host2host-diffNode.txt
+-rw-r--r--. 1 root root 2628 Jun 27 16:34 08-b-server-client-host2host-diffNode.txt
+-rw-r--r--. 1 root root 2835 Jun 27 16:34 09-a-client-server-host2clusterIpSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root 2627 Jun 27 16:35 09-a-server-client-host2clusterIpSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root 2835 Jun 27 16:40 09-b-client-server-host2clusterIpSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root 2627 Jun 27 16:40 09-b-server-client-host2clusterIpSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root 2834 Jun 27 16:45 10-a-client-server-host2clusterIpSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root 2626 Jun 27 16:45 10-a-server-client-host2clusterIpSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root 2833 Jun 27 16:50 10-b-client-server-host2clusterIpSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root 2625 Jun 27 16:50 10-b-server-client-host2clusterIpSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root 2838 Jun 27 16:55 11-a-client-server-host2nodePortSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root 2629 Jun 27 16:55 11-a-server-client-host2nodePortSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root 2839 Jun 27 17:00 11-b-client-server-host2nodePortSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root 2630 Jun 27 17:00 11-b-server-client-host2nodePortSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root 2776 Jun 27 17:05 12-a-client-server-host2nodePortSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root 2631 Jun 27 17:06 12-a-server-client-host2nodePortSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root  123 Jun 27 17:09 12-b-client-server-host2nodePortSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root 2630 Jun 27 17:10 12-b-server-client-host2nodePortSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root   71 Jun 27 15:36 .gitignore
 ```
 
 *NOTE:* The *'cleanup.sh'* script does not remove these files and each subsequent run of
@@ -731,264 +806,146 @@ FLOW 01: Pod to Pod traffic
 
 *** 1-a: Pod to Pod (Same Node) ***
 
-admin:worker-advnetlab48 -> admin:worker-advnetlab48
-kubectl exec -n default ft-client-pod-sriov-7c7kw -- curl -m 5 "http://10.131.0.7:8080/etc/httpserver/"
+=== CURL ===
+admin:worker-advnetlab26 -> admin:worker-advnetlab26
+kubectl exec -n default ft-client-pod-sriov-x2xd7 -- curl -m 5 "http://10.131.1.66:8080/etc/httpserver/"
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   164  100   164    0     0    346      0 --:--:-- --:--:-- --:--:--   346
+
 SUCCESS
 
-admin:worker-advnetlab48 -> admin:worker-advnetlab48
-Client Pod on Client Host VF Representor Results:
-kubectl exec -n default ft-client-pod-sriov-7c7kw --  iperf3  -c 10.131.0.8 -p 5201 -t 40
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "ethtool -S 5e4c68e6cdf0428 | sed -n 's/^\s\+//p'"
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 5e4c68e6cdf0428 -n not arp"
-Summary (see hwol-logs/01-a-pod2pod-sameNode.txt for full detail):
-Summary Ethtool results for 5e4c68e6cdf0428:
-RX Packets: 2110133 - 2110133 = 0
-TX Packets: 1529762921 - 1529762921 = 0
+=== HWOL ===
+== admin:worker-advnetlab26 -> admin:worker-advnetlab26 ==
+= Client Pod on Client Host VF Representor Results =
+kubectl exec -n default ft-client-pod-sriov-x2xd7 --  iperf3  -c 10.131.1.67 -p 5201 -t 40
+kubectl exec -n "default" "ft-tools-wlmt5" -- /bin/sh -c "ethtool -S 8a0d327328be763 | sed -n 's/^\s\+//p'"
+kubectl exec -n "default" "ft-tools-wlmt5" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 8a0d327328be763 -n not arp"
+Summary (see hwol-logs/01-a-client-server-pod2pod-sameNode.txt for full detail):
+Summary Ethtool results for 8a0d327328be763:
+RX Packets: 506930587 - 506930587 = 0
+TX Packets: 786188362 - 786188362 = 0
 Summary Tcpdump Output:
 dropped privs to tcpdump
-tcpdump: listening on 5e4c68e6cdf0428, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+tcpdump: listening on 8a0d327328be763, link-type EN10MB (Ethernet), snapshot length 262144 bytes
 0 packets captured
 0 packets received by filter
 0 packets dropped by kernel
 
 Summary Iperf Output:
 [ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-40.00  sec   147 GBytes  31.6 Gbits/sec  28331             sender
-[  5]   0.00-40.00  sec   147 GBytes  31.6 Gbits/sec                  receiver
+[  5]   0.00-40.00  sec   118 GBytes  25.4 Gbits/sec  18295             sender
+[  5]   0.00-40.00  sec   118 GBytes  25.4 Gbits/sec                  receiver
 
-Client Pod on Server Host VF Representor Results:
-kubectl exec -n default ft-client-pod-sriov-7c7kw --  iperf3  -c 10.131.0.8 -p 5201 -t 40
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "ethtool -S 5e4c68e6cdf0428 | sed -n 's/^\s\+//p'"
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 5e4c68e6cdf0428 -n not arp"
-Summary (see hwol-logs/01-a-pod2pod-sameNode.txt for full detail):
-Summary Ethtool results for 5e4c68e6cdf0428:
-RX Packets: 2111344 - 2111344 = 0
-TX Packets: 1529763129 - 1529763129 = 0
+= Client Pod on Server Host VF Representor Results =
+kubectl exec -n default ft-client-pod-sriov-x2xd7 --  iperf3  -c 10.131.1.67 -p 5201 -t 40
+kubectl exec -n "default" "ft-tools-wlmt5" -- /bin/sh -c "ethtool -S 8a0d327328be763 | sed -n 's/^\s\+//p'"
+kubectl exec -n "default" "ft-tools-wlmt5" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 8a0d327328be763 -n not arp"
+Summary (see hwol-logs/01-a-client-server-pod2pod-sameNode.txt for full detail):
+Summary Ethtool results for 8a0d327328be763:
+RX Packets: 506932996 - 506932996 = 0
+TX Packets: 786188458 - 786188458 = 0
 Summary Tcpdump Output:
 dropped privs to tcpdump
-tcpdump: listening on 5e4c68e6cdf0428, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+tcpdump: listening on 8a0d327328be763, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+
+0 packets captured
+0 packets received by filter
+0 packets dropped by kernel
+Summary Iperf Output:
+[ ID] Interval           Transfer     Bitrate         Retr
+[  5]   0.00-40.00  sec   119 GBytes  25.6 Gbits/sec  22480             sender
+[  5]   0.00-40.00  sec   119 GBytes  25.5 Gbits/sec                  receiver
+
+= Server Pod on Server Host VF Representor Results =
+kubectl exec -n default ft-client-pod-sriov-x2xd7 --  iperf3  -c 10.131.1.67 -p 5201 -t 40
+kubectl exec -n "default" "ft-tools-wlmt5" -- /bin/sh -c "ethtool -S 3ff7cd6d4ceea68 | sed -n 's/^\s\+//p'"
+kubectl exec -n "default" "ft-tools-wlmt5" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 3ff7cd6d4ceea68 -n not arp"
+Summary (see hwol-logs/01-a-client-server-pod2pod-sameNode.txt for full detail):
+Summary Ethtool results for 8a0d327328be763:
+RX Packets: 72890864 - 72890863 = 1
+TX Packets: 1188566712 - 1188566711 = 1
+Summary Tcpdump Output:
+dropped privs to tcpdump
+tcpdump: listening on 3ff7cd6d4ceea68, link-type EN10MB (Ethernet), snapshot length 262144 bytes
 0 packets captured
 0 packets received by filter
 0 packets dropped by kernel
 
 Summary Iperf Output:
 [ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-40.00  sec   128 GBytes  27.4 Gbits/sec  18819             sender
-[  5]   0.00-40.00  sec   128 GBytes  27.4 Gbits/sec                  receiver
+[  5]   0.00-40.00  sec   115 GBytes  24.8 Gbits/sec  20058             sender
+[  5]   0.00-40.00  sec   115 GBytes  24.8 Gbits/sec                  receiver
 
-Server Pod on Server Host VF Representor Results:
-kubectl exec -n default ft-client-pod-sriov-7c7kw --  iperf3  -c 10.131.0.8 -p 5201 -t 40
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "ethtool -S e934c8ad11a9898 | sed -n 's/^\s\+//p'"
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i e934c8ad11a9898 -n not arp"
-Summary (see hwol-logs/01-a-pod2pod-sameNode.txt for full detail):
-Summary Ethtool results for 5e4c68e6cdf0428:
-RX Packets: 49229067 - 49229067 = 0
-TX Packets: 256117386 - 256117386 = 0
-Summary Tcpdump Output:
-dropped privs to tcpdump
-tcpdump: listening on e934c8ad11a9898, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-0 packets captured
-0 packets received by filter
-0 packets dropped by kernel
-
-Summary Iperf Output:
-[ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-40.00  sec   129 GBytes  27.8 Gbits/sec  17577             sender
-[  5]   0.00-40.00  sec   129 GBytes  27.8 Gbits/sec                  receiver
 SUCCESS
 
-admin:worker-advnetlab48 -(Reverse)-> admin:worker-advnetlab48
-Client Pod on Client Host VF Representor Results (Reverse):
-kubectl exec -n default ft-client-pod-sriov-7c7kw --  iperf3 -R -c 10.131.0.8 -p 5201 -t 40
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "ethtool -S 5e4c68e6cdf0428 | sed -n 's/^\s\+//p'"
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 5e4c68e6cdf0428 -n not arp"
-Summary (see hwol-logs/01-a-pod2pod-sameNode.txt for full detail):
-Summary Ethtool results for 5e4c68e6cdf0428:
-RX Packets: 2111714 - 2111714 = 0
-TX Packets: 1529765249 - 1529765249 = 0
+== admin:worker-advnetlab26 -> admin:worker-advnetlab26 (Reverse) ==
+= Client Pod on Client Host VF Representor Results (Reverse) =
+kubectl exec -n default ft-client-pod-sriov-x2xd7 --  iperf3 -R -c 10.131.1.67 -p 5201 -t 40
+kubectl exec -n "default" "ft-tools-wlmt5" -- /bin/sh -c "ethtool -S 8a0d327328be763 | sed -n 's/^\s\+//p'"
+kubectl exec -n "default" "ft-tools-wlmt5" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 8a0d327328be763 -n not arp"
+Summary (see hwol-logs/01-a-server-client-pod2pod-sameNode.txt for full detail):
+Summary Ethtool results for 8a0d327328be763:
+RX Packets: 506935220 - 506935220 = 0
+TX Packets: 786189775 - 786189775 = 0
 Summary Tcpdump Output:
 dropped privs to tcpdump
-tcpdump: listening on 5e4c68e6cdf0428, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-
-0 packets captured
-0 packets received by filter
-0 packets dropped by kernel
-Summary Iperf Output:
-[ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-40.00  sec   144 GBytes  30.9 Gbits/sec  30382             sender
-[  5]   0.00-40.00  sec   144 GBytes  30.9 Gbits/sec                  receiver
-
-Client Pod on Server Host VF Representor Results (Reverse):
-kubectl exec -n default ft-client-pod-sriov-7c7kw --  iperf3 -R -c 10.131.0.8 -p 5201 -t 40
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "ethtool -S 5e4c68e6cdf0428 | sed -n 's/^\s\+//p'"
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 5e4c68e6cdf0428 -n not arp"
-Summary (see hwol-logs/01-a-pod2pod-sameNode.txt for full detail):
-Summary Ethtool results for 5e4c68e6cdf0428:
-RX Packets: 2111810 - 2111810 = 0
-TX Packets: 1529767130 - 1529767130 = 0
-Summary Tcpdump Output:
-dropped privs to tcpdump
-tcpdump: listening on 5e4c68e6cdf0428, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+tcpdump: listening on 8a0d327328be763, link-type EN10MB (Ethernet), snapshot length 262144 bytes
 0 packets captured
 0 packets received by filter
 0 packets dropped by kernel
 
 Summary Iperf Output:
 [ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-40.00  sec   131 GBytes  28.2 Gbits/sec  25898             sender
-[  5]   0.00-40.00  sec   131 GBytes  28.2 Gbits/sec                  receiver
+[  5]   0.00-40.00  sec   119 GBytes  25.5 Gbits/sec  20332             sender
+[  5]   0.00-40.00  sec   119 GBytes  25.5 Gbits/sec                  receiver
 
-Server Pod on Server Host VF Representor Results (Reverse):
-kubectl exec -n default ft-client-pod-sriov-7c7kw --  iperf3 -R -c 10.131.0.8 -p 5201 -t 40
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "ethtool -S e934c8ad11a9898 | sed -n 's/^\s\+//p'"
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i e934c8ad11a9898 -n not arp"
-Summary (see hwol-logs/01-a-pod2pod-sameNode.txt for full detail):
-Summary Ethtool results for 5e4c68e6cdf0428:
-RX Packets: 49241013 - 49241013 = 0
-TX Packets: 256117663 - 256117663 = 0
+= Client Pod on Server Host VF Representor Results (Reverse) =
+kubectl exec -n default ft-client-pod-sriov-x2xd7 --  iperf3 -R -c 10.131.1.67 -p 5201 -t 40
+kubectl exec -n "default" "ft-tools-wlmt5" -- /bin/sh -c "ethtool -S 8a0d327328be763 | sed -n 's/^\s\+//p'"
+kubectl exec -n "default" "ft-tools-wlmt5" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 8a0d327328be763 -n not arp"
+Summary (see hwol-logs/01-a-server-client-pod2pod-sameNode.txt for full detail):
+Summary Ethtool results for 8a0d327328be763:
+RX Packets: 506935309 - 506935309 = 0
+TX Packets: 786192678 - 786192678 = 0
 Summary Tcpdump Output:
 dropped privs to tcpdump
-tcpdump: listening on e934c8ad11a9898, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+tcpdump: listening on 8a0d327328be763, link-type EN10MB (Ethernet), snapshot length 262144 bytes
 0 packets captured
 0 packets received by filter
 0 packets dropped by kernel
 
 Summary Iperf Output:
 [ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-40.00  sec   124 GBytes  26.7 Gbits/sec  16422             sender
-[  5]   0.00-40.00  sec   124 GBytes  26.7 Gbits/sec                  receiver
+[  5]   0.00-40.00  sec   118 GBytes  25.3 Gbits/sec  20214             sender
+[  5]   0.00-40.00  sec   118 GBytes  25.3 Gbits/sec                  receiver
+
+= Server Pod on Server Host VF Representor Results (Reverse) =
+kubectl exec -n default ft-client-pod-sriov-x2xd7 --  iperf3 -R -c 10.131.1.67 -p 5201 -t 40
+kubectl exec -n "default" "ft-tools-wlmt5" -- /bin/sh -c "ethtool -S 3ff7cd6d4ceea68 | sed -n 's/^\s\+//p'"
+kubectl exec -n "default" "ft-tools-wlmt5" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 3ff7cd6d4ceea68 -n not arp"
+Summary (see hwol-logs/01-a-server-client-pod2pod-sameNode.txt for full detail):
+Summary Ethtool results for 8a0d327328be763:
+RX Packets: 72898350 - 72898350 = 0
+TX Packets: 1188566934 - 1188566934 = 0
+Summary Tcpdump Output:
+dropped privs to tcpdump
+tcpdump: listening on 3ff7cd6d4ceea68, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+0 packets captured
+0 packets received by filter
+0 packets dropped by kernel
+
+Summary Iperf Output:
+[ ID] Interval           Transfer     Bitrate         Retr
+[  5]   0.00-40.00  sec   118 GBytes  25.3 Gbits/sec  23220             sender
+[  5]   0.00-40.00  sec   118 GBytes  25.3 Gbits/sec                  receiver
+
 SUCCESS
 
 
 *** 1-b: Pod to Pod (Different Node) ***
 
-admin:worker-advnetlab49 -> admin:worker-advnetlab48
-kubectl exec -n default ft-client-pod-sriov-5g7s5 -- curl -m 5 "http://10.131.0.7:8080/etc/httpserver/"
-SUCCESS
-
-admin:worker-advnetlab49 -> admin:worker-advnetlab48
-Client Pod on Client Host VF Representor Results:
-kubectl exec -n default ft-client-pod-sriov-5g7s5 --  iperf3 -R -c 10.131.0.8 -p 5201 -t 40
-kubectl exec -n "default" "ft-tools-tcdcf" -- /bin/sh -c "ethtool -S 71f6388f057f493 | sed -n 's/^\s\+//p'"
-kubectl exec -n "default" "ft-tools-tcdcf" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 71f6388f057f493 -n not arp"
-Summary (see hwol-logs/01-b-pod2pod-diffNode.txt for full detail):
-Summary Ethtool results for 71f6388f057f493:
-RX Packets: 29709701 - 29709701 = 0
-TX Packets: 16373115 - 16373115 = 0
-Summary Tcpdump Output:
-dropped privs to tcpdump
-tcpdump: listening on 71f6388f057f493, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-0 packets captured
-0 packets received by filter
-0 packets dropped by kernel
-
-Summary Iperf Output:
-[ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-40.00  sec  80.1 GBytes  17.2 Gbits/sec  1886             sender
-[  5]   0.00-40.00  sec  80.1 GBytes  17.2 Gbits/sec                  receiver
-
-Client Pod on Server Host VF Representor Results:
-kubectl exec -n default ft-client-pod-sriov-5g7s5 --  iperf3 -R -c 10.131.0.8 -p 5201 -t 40
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "ethtool -S 5e4c68e6cdf0428 | sed -n 's/^\s\+//p'"
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 5e4c68e6cdf0428 -n not arp"
-Summary (see hwol-logs/01-b-pod2pod-diffNode.txt for full detail):
-Summary Ethtool results for 71f6388f057f493:
-RX Packets: 2111927 - 2111927 = 0
-TX Packets: 1529775109 - 1529775109 = 0
-Summary Tcpdump Output:
-dropped privs to tcpdump
-tcpdump: listening on 5e4c68e6cdf0428, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-0 packets captured
-0 packets received by filter
-0 packets dropped by kernel
-
-Summary Iperf Output:
-[ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-40.00  sec  85.1 GBytes  18.3 Gbits/sec  2989             sender
-[  5]   0.00-40.00  sec  85.1 GBytes  18.3 Gbits/sec                  receiver
-
-Server Pod on Server Host VF Representor Results:
-kubectl exec -n default ft-client-pod-sriov-5g7s5 --  iperf3 -R -c 10.131.0.8 -p 5201 -t 40
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "ethtool -S e934c8ad11a9898 | sed -n 's/^\s\+//p'"
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i e934c8ad11a9898 -n not arp"
-Summary (see hwol-logs/01-b-pod2pod-diffNode.txt for full detail):
-Summary Ethtool results for 71f6388f057f493:
-RX Packets: 49246837 - 49246837 = 0
-TX Packets: 256117890 - 256117890 = 0
-Summary Tcpdump Output:
-dropped privs to tcpdump
-tcpdump: listening on e934c8ad11a9898, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-0 packets captured
-0 packets received by filter
-0 packets dropped by kernel
-
-Summary Iperf Output:
-[ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-40.00  sec  99.3 GBytes  21.3 Gbits/sec  6364             sender
-[  5]   0.00-40.00  sec  99.3 GBytes  21.3 Gbits/sec                  receiver
-SUCCESS
-
-admin:worker-advnetlab49 -(Reverse)-> admin:worker-advnetlab48
-Client Pod on Client Host VF Representor Results (Reverse):
-kubectl exec -n default ft-client-pod-sriov-5g7s5 --  iperf3 -R -c 10.131.0.8 -p 5201 -t 40
-kubectl exec -n "default" "ft-tools-tcdcf" -- /bin/sh -c "ethtool -S 71f6388f057f493 | sed -n 's/^\s\+//p'"
-kubectl exec -n "default" "ft-tools-tcdcf" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 71f6388f057f493 -n not arp"
-Summary (see hwol-logs/01-b-pod2pod-diffNode.txt for full detail):
-Summary Ethtool results for 71f6388f057f493:
-RX Packets: 29709735 - 29709735 = 0
-TX Packets: 16373234 - 16373234 = 0
-Summary Tcpdump Output:
-dropped privs to tcpdump
-tcpdump: listening on 71f6388f057f493, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-0 packets captured
-0 packets received by filter
-0 packets dropped by kernel
-
-Summary Iperf Output:
-[ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-40.00  sec  88.4 GBytes  19.0 Gbits/sec  5081             sender
-[  5]   0.00-40.00  sec  88.4 GBytes  19.0 Gbits/sec                  receiver
-
-Client Pod on Server Host VF Representor Results (Reverse):
-kubectl exec -n default ft-client-pod-sriov-5g7s5 --  iperf3 -R -c 10.131.0.8 -p 5201 -t 40
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "ethtool -S 5e4c68e6cdf0428 | sed -n 's/^\s\+//p'"
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i 5e4c68e6cdf0428 -n not arp"
-Summary (see hwol-logs/01-b-pod2pod-diffNode.txt for full detail):
-Summary Ethtool results for 71f6388f057f493:
-RX Packets: 2111927 - 2111927 = 0
-TX Packets: 1529775109 - 1529775109 = 0
-Summary Tcpdump Output:
-dropped privs to tcpdump
-tcpdump: listening on 5e4c68e6cdf0428, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-0 packets captured
-0 packets received by filter
-0 packets dropped by kernel
-
-Summary Iperf Output:
-[ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-40.00  sec   100 GBytes  21.6 Gbits/sec  7092             sender
-[  5]   0.00-40.00  sec   100 GBytes  21.6 Gbits/sec                  receiver
-
-Server Pod on Server Host VF Representor Results (Reverse):
-kubectl exec -n default ft-client-pod-sriov-5g7s5 --  iperf3 -R -c 10.131.0.8 -p 5201 -t 40
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "ethtool -S e934c8ad11a9898 | sed -n 's/^\s\+//p'"
-kubectl exec -n "default" "ft-tools-brxwg" -- /bin/sh -c "timeout --preserve-status 25 tcpdump -v -i e934c8ad11a9898 -n not arp"
-Summary (see hwol-logs/01-b-pod2pod-diffNode.txt for full detail):
-Summary Ethtool results for 71f6388f057f493:
-RX Packets: 49251327 - 49251327 = 0
-TX Packets: 256118048 - 256118048 = 0
-Summary Tcpdump Output:
-dropped privs to tcpdump
-tcpdump: listening on e934c8ad11a9898, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-0 packets captured
-0 packets received by filter
-0 packets dropped by kernel
-
-Summary Iperf Output:
-[ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-40.00  sec   101 GBytes  21.6 Gbits/sec  5579             sender
-[  5]   0.00-40.00  sec   101 GBytes  21.6 Gbits/sec                  receiver
-SUCCESS
+:
 ```
 
 When Hardware Offload Validation is run on each sub-flow, the full output of the command
@@ -998,29 +955,47 @@ when command is executed to see full output command is run. Below is a list of s
 files:
 
 ```
-$ ls -al hwol-logs/
-total 5906976
-drwxr-xr-x. 2 root root       4096 Jun  9 12:24 .
-drwxr-xr-x. 9 root root       4096 Jun  9 10:27 ..
--rw-r--r--. 1 root root      24807 Jun  9 12:20 01-a-pod2pod-sameNode.txt
--rw-r--r--. 1 root root      23907 Jun  9 12:24 01-b-pod2pod-diffNode.txt
--rw-r--r--. 1 root root      24090 Jun  9 10:44 03-a-pod2clusterIpSvc-podBackend-sameNode.txt
--rw-r--r--. 1 root root      23864 Jun  9 10:50 03-b-pod2clusterIpSvc-podBackend-diffNode.txt
--rw-r--r--. 1 root root 2083508963 Jun  9 10:55 04-a-pod2clusterIpSvc-hostBackend-sameNode.txt
--rw-r--r--. 1 root root  258572217 Jun  9 11:00 04-b-pod2clusterIpSvc-hostBackend-diffNode.txt
--rw-r--r--. 1 root root      23929 Jun  9 11:05 05-a-pod2nodePortSvc-podBackend-sameNode.txt
--rw-r--r--. 1 root root  263024539 Jun  9 11:10 05-b-pod2nodePortSvc-podBackend-diffNode.txt
--rw-r--r--. 1 root root 1954959733 Jun  9 11:15 06-a-pod2nodePortSvc-hostBackend-sameNode.txt
--rw-r--r--. 1 root root  250297501 Jun  9 11:20 06-b-pod2nodePortSvc-hostBackend-diffNode.txt
--rw-r--r--. 1 root root  558443546 Jun  9 11:29 09-a-host2clusterIpSvc-podBackend-sameNode.txt
--rw-r--r--. 1 root root      24199 Jun  9 11:35 09-b-host2clusterIpSvc-podBackend-diffNode.txt
--rw-r--r--. 1 root root      23974 Jun  9 11:40 10-a-host2clusterIpSvc-hostBackend-sameNode.txt
--rw-r--r--. 1 root root      23955 Jun  9 11:45 10-b-host2clusterIpSvc-hostBackend-diffNode.txt
--rw-r--r--. 1 root root  524801984 Jun  9 11:50 11-a-host2nodePortSvc-podBackend-sameNode.txt
--rw-r--r--. 1 root root  154867716 Jun  9 11:55 11-b-host2nodePortSvc-podBackend-diffNode.txt
--rw-r--r--. 1 root root      15664 Jun  9 11:59 12-a-host2nodePortSvc-hostBackend-sameNode.txt
--rw-r--r--. 1 root root      24008 Jun  9 12:04 12-b-host2nodePortSvc-hostBackend-diffNode.txt
--rw-r--r--. 1 root root         70 Jun  9 10:27 .gitignore
+$ ls -la
+total 9202220
+drwxr-xr-x. 2 root root       4096 Jun 27 17:13 .
+drwxr-xr-x. 9 root root       4096 Jun 27 15:36 ..
+-rw-r--r--. 1 root root      12933 Jun 27 15:40 01-a-client-server-pod2pod-sameNode.txt
+-rw-r--r--. 1 root root     498488 Jun 27 15:42 01-a-server-client-pod2pod-sameNode.txt
+-rw-r--r--. 1 root root  746031347 Jun 27 15:45 01-b-client-server-pod2pod-diffNode.txt
+-rw-r--r--. 1 root root  757263512 Jun 27 15:47 01-b-server-client-pod2pod-diffNode.txt
+-rw-r--r--. 1 root root      12829 Jun 27 15:52 03-a-client-server-pod2clusterIpSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root      11993 Jun 27 15:54 03-a-server-client-pod2clusterIpSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root  743947340 Jun 27 15:57 03-b-client-server-pod2clusterIpSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root  763566463 Jun 27 15:59 03-b-server-client-pod2clusterIpSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root  646183167 Jun 27 16:02 04-a-client-server-pod2clusterIpSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root 1197152583 Jun 27 16:04 04-a-server-client-pod2clusterIpSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root  143015503 Jun 27 16:07 04-b-client-server-pod2clusterIpSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root  103515987 Jun 27 16:09 04-b-server-client-pod2clusterIpSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root      12869 Jun 27 16:12 05-a-client-server-pod2nodePortSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root      12027 Jun 27 16:14 05-a-server-client-pod2nodePortSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root  103712806 Jun 27 16:18 05-b-client-server-pod2nodePortSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root  102064701 Jun 27 16:20 05-b-server-client-pod2nodePortSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root  636825401 Jun 27 16:23 06-a-client-server-pod2nodePortSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root 1136208125 Jun 27 16:25 06-a-server-client-pod2nodePortSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root   88201000 Jun 27 16:28 06-b-client-server-pod2nodePortSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root   97731608 Jun 27 16:30 06-b-server-client-pod2nodePortSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root  512896760 Jun 27 16:37 09-a-client-server-host2clusterIpSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root  214469570 Jun 27 16:39 09-a-server-client-host2clusterIpSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root  434620472 Jun 27 16:42 09-b-client-server-host2clusterIpSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root  198723790 Jun 27 16:44 09-b-server-client-host2clusterIpSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root      12869 Jun 27 16:47 10-a-client-server-host2clusterIpSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root      12035 Jun 27 16:49 10-a-server-client-host2clusterIpSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root      12854 Jun 27 16:52 10-b-client-server-host2clusterIpSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root      12019 Jun 27 16:54 10-b-server-client-host2clusterIpSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root  438399942 Jun 27 16:57 11-a-client-server-host2nodePortSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root  220658127 Jun 27 16:59 11-a-server-client-host2nodePortSvc-podBackend-sameNode.txt
+-rw-r--r--. 1 root root   79049834 Jun 27 17:02 11-b-client-server-host2nodePortSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root   58111736 Jun 27 17:05 11-b-server-client-host2nodePortSvc-podBackend-diffNode.txt
+-rw-r--r--. 1 root root      12883 Jun 27 17:08 12-a-client-server-host2nodePortSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root       7090 Jun 27 17:09 12-a-server-client-host2nodePortSvc-hostBackend-sameNode.txt
+-rw-r--r--. 1 root root       2356 Jun 27 17:11 12-b-client-server-host2nodePortSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root      12037 Jun 27 17:13 12-b-server-client-host2nodePortSvc-hostBackend-diffNode.txt
+-rw-r--r--. 1 root root         70 Jun 27 15:36 .gitignore
 ```
 
 *NOTE:* The *'cleanup.sh'* script does not remove these files and each subsequent run of

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -82,5 +82,6 @@ fi
 if [ "$CLEAN_ALL" == true ]; then
   rm -rf manifests/yamls/*.yaml
   rm -rf iperf-logs/*.txt
+  rm -rf hwol-logs/*.txt
   rm -rf ovn-traces/*.txt
 fi

--- a/docs/IMAGES.md
+++ b/docs/IMAGES.md
@@ -71,7 +71,7 @@ sudo podman manifest push ft-base-image-0.9-list quay.io/billy99/ft-base-image:0
 ## tools
 
 The `ft-tools` pod uses a Centos Stream9 image base with root/privileged access to the host.
-Many tools and debug packages pulled in (Please see images/ft-tools/Containerfile for details).
+Many tools and debug packages are pulled in (See images/ft-tools/Containerfile for details).
 The image has been built and pushed to `quay.io` for use by this repo.
 
 ```

--- a/docs/IMAGES.md
+++ b/docs/IMAGES.md
@@ -6,7 +6,7 @@ This document describes the container images used by this repo and how to rebuil
 ## Table of Contents
 
 - [http-server, iperf-server and client Images](#http-server-iperf-server-and-client-images)
-
+- [tools](#tools)
 
 ## http-server, iperf-server and client Images
 
@@ -70,4 +70,58 @@ sudo podman manifest push ft-base-image-0.9-list quay.io/billy99/ft-base-image:0
 
 ## tools
 
-This is not a private image. Just using https://github.com/nicolaka/netshoot as the tools image.
+The `ft-tools` pod uses a Centos Stream9 image base with root/privileged access to the host.
+Many tools and debug packages pulled in (Please see images/ft-tools/Containerfile for details).
+The image has been built and pushed to `quay.io` for use by this repo.
+
+```
+quay.io/wizhao/ft-tools:0.9
+```
+
+The image has been built for multi-arch. The image must be built for each architecture
+on a machine of that architecture. Then a manifest is created, pointing to each
+architecture image.
+
+From `x86` machine:
+
+```
+mkdir -p ~/src/; cd ~/src/
+git clone https://github.com/billy99/ovn-kuber-traffic-flow-tests.git
+cd ~/src/ovn-kuber-traffic-flow-tests/images/ft-tools/
+
+sudo podman build -t quay.io/wizhao/ft-tools:0.9-x86_64 -f ./Containerfile .
+
+sudo podman login quay.io
+sudo podman push quay.io/wizhao/ft-tools:0.9-x86_64
+```
+
+From `arm` machine:
+
+```
+mkdir -p ~/src/; cd ~/src/
+git clone https://github.com/billy99/ovn-kuber-traffic-flow-tests.git
+cd ~/src/ovn-kuber-traffic-flow-tests/images/ft-tools/
+
+sudo podman build -t quay.io/wizhao/ft-tools:0.9-aarch64 -f ./Containerfile .
+
+sudo podman login quay.io
+sudo podman push quay.io/wizhao/ft-tools:0.9-aarch64
+```
+Or from an x86 server:
+```
+sudo podman build --platform linux/arm64 -t quay.io/wizhao/ft-tools:0.9-aarch64 -f ./Containerfile .
+```
+
+From any machine:
+```
+sudo podman manifest create ft-tools-0.9-list
+
+sudo podman pull quay.io/wizhao/ft-tools:0.9-x86_64
+sudo podman manifest add ft-tools-0.9-list quay.io/wizhao/ft-tools:0.9-x86_64
+
+sudo podman pull quay.io/wizhao/ft-tools:0.9-aarch64
+sudo podman manifest add ft-tools-0.9-list quay.io/wizhao/ft-tools:0.9-aarch64
+
+sudo podman login quay.io
+sudo podman manifest push ft-tools-0.9-list quay.io/wizhao/ft-tools:0.9
+```

--- a/hwol-logs/.gitignore
+++ b/hwol-logs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/images/ft-tools/Containerfile
+++ b/images/ft-tools/Containerfile
@@ -1,0 +1,8 @@
+FROM quay.io/centos/amd64:stream9
+
+RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/CentOS_8/devel:kubic:libcontainers:stable.repo \
+curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:${VERSION}.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:${VERSION}/CentOS_8/devel:kubic:libcontainers:stable:cri-o:${VERSION}.repo
+
+RUN INSTALL_PKGS="vim wget jq git cri-tools net-tools iproute pciutils ethtool httpd iperf3 tcpdump util-linux" && yum install -y ${INSTALL_PKGS}
+
+CMD ["/bin/bash"]

--- a/manifests/tools-daemonSet.yaml.j2
+++ b/manifests/tools-daemonSet.yaml.j2
@@ -19,11 +19,28 @@ spec:
       hostNetwork: true
       containers:
       - name: ft-tools
-        image: nicolaka/netshoot
+        image: quay.io/wizhao/ft-tools:0.9
         command:
           - /sbin/init
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
-      nodeSelector:
-        ft.ClientPod: client
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /host
+          name: host
+      volumes:
+      - hostPath:
+          path: /
+          type: Directory
+        name: host
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: ft.ClientPod
+                operator: In
+                values:
+                - sriov
+                - client

--- a/process-cmds.sh
+++ b/process-cmds.sh
@@ -33,8 +33,8 @@ process-curl() {
     TMP_OUTPUT=`$CURL_CMD "http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}${SERVER_PATH}"`
   elif [ -z "${TEST_SERVER_HTTP_DST_PORT}" ]; then
     # No Port, so leave off Port from command
-    echo "kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}/\""
-    TMP_OUTPUT=`kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD "http://${TEST_SERVER_HTTP_DST}/"`
+    echo "kubectl exec -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}/\""
+    TMP_OUTPUT=`kubectl exec -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD "http://${TEST_SERVER_HTTP_DST}/"`
   else
     # Default command
 
@@ -42,15 +42,15 @@ process-curl() {
     if [ "${TEST_SERVER_RSP}" == "${KUBEAPI_SERVER_STRING}" ]; then
       LCL_SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
 
-      echo "LCL_TOKEN=kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- cat ${LCL_SERVICEACCOUNT}/token"
-      LCL_TOKEN=`kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- cat ${LCL_SERVICEACCOUNT}/token`
+      echo "LCL_TOKEN=kubectl exec -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- cat ${LCL_SERVICEACCOUNT}/token"
+      LCL_TOKEN=`kubectl exec -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- cat ${LCL_SERVICEACCOUNT}/token`
 
-      echo "kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD --cacert ${LCL_SERVICEACCOUNT}/ca.crt  -H \"Authorization: Bearer LCL_TOKEN\" -X GET \"https://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/api\""
-      TMP_OUTPUT=`kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD --cacert ${LCL_SERVICEACCOUNT}/ca.crt  -H "Authorization: Bearer ${LCL_TOKEN}" -X GET "https://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/api"`
+      echo "kubectl exec -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD --cacert ${LCL_SERVICEACCOUNT}/ca.crt  -H \"Authorization: Bearer LCL_TOKEN\" -X GET \"https://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/api\""
+      TMP_OUTPUT=`kubectl exec -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD --cacert ${LCL_SERVICEACCOUNT}/ca.crt  -H "Authorization: Bearer ${LCL_TOKEN}" -X GET "https://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}/api"`
     else
       #kubectl config get-contexts
-      echo "kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}${SERVER_PATH}\""
-      TMP_OUTPUT=`kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD "http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}${SERVER_PATH}"`
+      echo "kubectl exec -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD \"http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}${SERVER_PATH}\""
+      TMP_OUTPUT=`kubectl exec -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- $CURL_CMD "http://${TEST_SERVER_HTTP_DST}:${TEST_SERVER_HTTP_DST_PORT}${SERVER_PATH}"`
     fi
   fi
 
@@ -74,12 +74,11 @@ process-iperf() {
     TASKSET_CMD="taskset ${FT_CLIENT_CPU_MASK} "
   fi
 
-  echo "${MY_CLUSTER}:${TEST_CLIENT_NODE} -> ${TEST_SERVER_CLUSTER}:${TEST_SERVER_NODE}"
-
   IPERF_FILENAME="${IPERF_LOGS_DIR}/${TEST_FILENAME}"
 
-  echo "kubectl exec -it -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- ${TASKSET_CMD}${IPERF_CMD} -c ${TEST_SERVER_IPERF_DST} -p ${TEST_SERVER_IPERF_DST_PORT} -t ${IPERF_TIME}"
-  kubectl exec -it -n "${FT_NAMESPACE}" "$TEST_CLIENT_POD" -- /bin/sh -c "${TASKSET_CMD} ${IPERF_CMD} -c ${TEST_SERVER_IPERF_DST} -p ${TEST_SERVER_IPERF_DST_PORT} -t ${IPERF_TIME}"  > "${IPERF_FILENAME}"
+  echo "${MY_CLUSTER}:${TEST_CLIENT_NODE} -> ${TEST_SERVER_CLUSTER}:${TEST_SERVER_NODE}"
+  echo "kubectl exec -n ${FT_NAMESPACE} ${TEST_CLIENT_POD} -- ${TASKSET_CMD} ${IPERF_CMD} -c ${TEST_SERVER_IPERF_DST} -p ${TEST_SERVER_IPERF_DST_PORT} -t ${IPERF_TIME}"
+  kubectl exec -n "${FT_NAMESPACE}" "$TEST_CLIENT_POD" -- /bin/sh -c "${TASKSET_CMD} ${IPERF_CMD} -c ${TEST_SERVER_IPERF_DST} -p ${TEST_SERVER_IPERF_DST_PORT} -t ${IPERF_TIME}"  > "${IPERF_FILENAME}"
 
   # Dump command output
   if [ "$VERBOSE" == true ]; then

--- a/test.sh
+++ b/test.sh
@@ -85,10 +85,15 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 1 ] && [ "$FT_HOSTONLY" == false ]
     process-curl
   fi
 
-  if [ "$IPERF" == true ]; then
+  if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
     TEST_SERVER_IPERF_DST=$IPERF_SERVER_POD_IP
     TEST_SERVER_IPERF_DST_PORT=$IPERF_CLUSTERIP_POD_SVC_PORT
-    process-iperf
+    if [ "$IPERF" == true ]; then
+      process-iperf
+    fi
+    if [ "$HWOL" == true ]; then
+      process-hw-offload-validation
+    fi
   fi
 
   if [ "$OVN_TRACE" == true ]; then
@@ -120,10 +125,15 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 1 ] && [ "$FT_HOSTONLY" == false ]
       process-curl
     fi
 
-    if [ "$IPERF" == true ]; then
+    if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
       TEST_SERVER_IPERF_DST=$IPERF_SERVER_POD_IP
       TEST_SERVER_IPERF_DST_PORT=$IPERF_CLUSTERIP_POD_SVC_PORT
-      process-iperf
+      if [ "$IPERF" == true ]; then
+        process-iperf
+      fi
+      if [ "$HWOL" == true ]; then
+        process-hw-offload-validation
+      fi
     fi
 
     if [ "$OVN_TRACE" == true ]; then
@@ -256,13 +266,18 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 3 ] && [ "$FT_HOSTONLY" == false ]
     process-curl
   fi
 
-  if [ "$IPERF" == true ]; then
+  if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
     for j in "${!IPERF_CLUSTERIP_POD_SVC_IPV4_LIST[@]}"
     do
       TEST_SERVER_IPERF_DST=${IPERF_CLUSTERIP_POD_SVC_IPV4_LIST[$j]}
       TEST_SERVER_IPERF_DST_PORT=$IPERF_CLUSTERIP_POD_SVC_PORT
       TEST_SERVER_CLUSTER=${IPERF_CLUSTERIP_POD_SVC_CLUSTER_LIST[$j]}
-      process-iperf
+      if [ "$IPERF" == true ]; then
+        process-iperf
+      fi
+      if [ "$HWOL" == true ]; then
+        process-hw-offload-validation
+      fi
     done
   fi
 
@@ -319,13 +334,18 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 3 ] && [ "$FT_HOSTONLY" == false ]
       process-curl
     fi
 
-    if [ "$IPERF" == true ]; then
+    if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
       for j in "${!IPERF_CLUSTERIP_POD_SVC_IPV4_LIST[@]}"
       do
         TEST_SERVER_IPERF_DST=${IPERF_CLUSTERIP_POD_SVC_IPV4_LIST[$j]}
         TEST_SERVER_IPERF_DST_PORT=$IPERF_CLUSTERIP_POD_SVC_PORT
         TEST_SERVER_CLUSTER=${IPERF_CLUSTERIP_POD_SVC_CLUSTER_LIST[$j]}
-        process-iperf
+        if [ "$IPERF" == true ]; then
+          process-iperf
+        fi
+        if [ "$HWOL" == true ]; then
+          process-hw-offload-validation
+        fi
       done
     fi
 
@@ -386,13 +406,18 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 4 ] && [ "$FT_HOSTONLY" == false ]
     process-curl
   fi
 
-  if [ "$IPERF" == true ]; then
+  if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
     for j in "${!IPERF_CLUSTERIP_HOST_SVC_IPV4_LIST[@]}"
     do
       TEST_SERVER_IPERF_DST=${IPERF_CLUSTERIP_HOST_SVC_IPV4_LIST[$j]}
       TEST_SERVER_IPERF_DST_PORT=$IPERF_CLUSTERIP_HOST_SVC_PORT
       TEST_SERVER_CLUSTER=${IPERF_CLUSTERIP_HOST_SVC_CLUSTER_LIST[$j]}
-      process-iperf
+      if [ "$IPERF" == true ]; then
+        process-iperf
+      fi
+      if [ "$HWOL" == true ]; then
+        process-hw-offload-validation
+      fi
     done
   fi
 
@@ -449,13 +474,18 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 4 ] && [ "$FT_HOSTONLY" == false ]
       process-curl
     fi
 
-    if [ "$IPERF" == true ]; then
+    if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
       for j in "${!IPERF_CLUSTERIP_HOST_SVC_IPV4_LIST[@]}"
       do
         TEST_SERVER_IPERF_DST=${IPERF_CLUSTERIP_HOST_SVC_IPV4_LIST[$j]}
         TEST_SERVER_IPERF_DST_PORT=$IPERF_CLUSTERIP_HOST_SVC_PORT
         TEST_SERVER_CLUSTER=${IPERF_CLUSTERIP_HOST_SVC_CLUSTER_LIST[$j]}
-        process-iperf
+        if [ "$IPERF" == true ]; then
+          process-iperf
+        fi
+        if [ "$HWOL" == true ]; then
+          process-hw-offload-validation
+        fi
       done
     fi
 
@@ -510,11 +540,16 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 5 ] && [ "$FT_HOSTONLY" == false ]
     process-curl
   fi
 
-  if [ "$IPERF" == true ]; then
+  if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
     TEST_SERVER_IPERF_DST=$IPERF_SERVER_HOST_IP
     TEST_SERVER_IPERF_DST_PORT=$IPERF_NODEPORT_POD_SVC_PORT
     TEST_SERVER_CLUSTER=$MY_CLUSTER
-    process-iperf
+    if [ "$IPERF" == true ]; then
+      process-iperf
+    fi
+    if [ "$HWOL" == true ]; then
+      process-hw-offload-validation
+    fi
   fi
 
   if [ "$OVN_TRACE" == true ]; then
@@ -562,11 +597,16 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 5 ] && [ "$FT_HOSTONLY" == false ]
       process-curl
     fi
 
-    if [ "$IPERF" == true ]; then
+    if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
       TEST_SERVER_IPERF_DST=$IPERF_SERVER_HOST_IP
       TEST_SERVER_IPERF_DST_PORT=$IPERF_NODEPORT_POD_SVC_PORT
       TEST_SERVER_CLUSTER=$MY_CLUSTER
-      process-iperf
+      if [ "$IPERF" == true ]; then
+        process-iperf
+      fi
+      if [ "$HWOL" == true ]; then
+        process-hw-offload-validation
+      fi
     fi
 
     if [ "$OVN_TRACE" == true ]; then
@@ -620,11 +660,16 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 6 ] && [ "$FT_HOSTONLY" == false ]
     process-curl
   fi
 
-  if [ "$IPERF" == true ]; then
+  if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
     TEST_SERVER_IPERF_DST=$IPERF_SERVER_HOST_IP
     TEST_SERVER_IPERF_DST_PORT=$IPERF_NODEPORT_HOST_SVC_PORT
     TEST_SERVER_CLUSTER=$MY_CLUSTER
-    process-iperf
+    if [ "$IPERF" == true ]; then
+      process-iperf
+    fi
+    if [ "$HWOL" == true ]; then
+      process-hw-offload-validation
+    fi
   fi
 
   if [ "$OVN_TRACE" == true ]; then
@@ -674,11 +719,16 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 6 ] && [ "$FT_HOSTONLY" == false ]
       process-curl
     fi
 
-    if [ "$IPERF" == true ]; then
+    if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
       TEST_SERVER_IPERF_DST=$IPERF_SERVER_HOST_IP
       TEST_SERVER_IPERF_DST_PORT=$IPERF_NODEPORT_HOST_SVC_PORT
       TEST_SERVER_CLUSTER=$MY_CLUSTER
-      process-iperf
+      if [ "$IPERF" == true ]; then
+        process-iperf
+      fi
+      if [ "$HWOL" == true ]; then
+        process-hw-offload-validation
+      fi
     fi
 
     if [ "$OVN_TRACE" == true ]; then
@@ -863,7 +913,7 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 9 ] && [ "$FT_HOSTONLY" == false ]
   echo
   echo "*** 9-a: Host Pod -> Cluster IP Service traffic (Pod Backend - Same Node) ***"
   echo
-  
+
   TEST_CLIENT_POD=$LOCAL_CLIENT_HOST_POD
   TEST_CLIENT_NODE=$LOCAL_CLIENT_NODE
   TEST_SERVER_NODE=$SERVER_POD_NODE
@@ -900,13 +950,18 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 9 ] && [ "$FT_HOSTONLY" == false ]
     process-curl
   fi
 
-  if [ "$IPERF" == true ]; then
+  if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
     for j in "${!IPERF_CLUSTERIP_POD_SVC_IPV4_LIST[@]}"
     do
       TEST_SERVER_IPERF_DST=${IPERF_CLUSTERIP_POD_SVC_IPV4_LIST[$j]}
       TEST_SERVER_IPERF_DST_PORT=$IPERF_CLUSTERIP_POD_SVC_PORT
       TEST_SERVER_CLUSTER=${IPERF_CLUSTERIP_POD_SVC_CLUSTER_LIST[$j]}
-      process-iperf
+      if [ "$IPERF" == true ]; then
+        process-iperf
+      fi
+      if [ "$HWOL" == true ]; then
+        process-hw-offload-validation
+      fi
     done
   fi
 
@@ -923,7 +978,7 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 9 ] && [ "$FT_HOSTONLY" == false ]
   echo
   echo "*** 9-b: Host Pod -> Cluster IP Service traffic (Pod Backend - Different Node) ***"
   echo
-  
+
   TEST_SERVER_NODE=$SERVER_POD_NODE
   TEST_FILENAME="09-b-host2clusterIpSvc-podBackend-diffNode.txt"
 
@@ -963,13 +1018,18 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 9 ] && [ "$FT_HOSTONLY" == false ]
       process-curl
     fi
 
-    if [ "$IPERF" == true ]; then
+    if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
       for j in "${!IPERF_CLUSTERIP_POD_SVC_IPV4_LIST[@]}"
       do
         TEST_SERVER_IPERF_DST=${IPERF_CLUSTERIP_POD_SVC_IPV4_LIST[$j]}
         TEST_SERVER_IPERF_DST_PORT=$IPERF_CLUSTERIP_POD_SVC_PORT
         TEST_SERVER_CLUSTER=${IPERF_CLUSTERIP_POD_SVC_CLUSTER_LIST[$j]}
-        process-iperf
+        if [ "$IPERF" == true ]; then
+          process-iperf
+        fi
+        if [ "$HWOL" == true ]; then
+          process-hw-offload-validation
+        fi
       done
     fi
 
@@ -1030,13 +1090,18 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 10 ]; then
     process-curl
   fi
 
-  if [ "$IPERF" == true ]; then
+  if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
     for j in "${!IPERF_CLUSTERIP_HOST_SVC_IPV4_LIST[@]}"
     do
       TEST_SERVER_IPERF_DST=${IPERF_CLUSTERIP_HOST_SVC_IPV4_LIST[$j]}
       TEST_SERVER_IPERF_DST_PORT=$IPERF_CLUSTERIP_HOST_SVC_PORT
       TEST_SERVER_CLUSTER=${IPERF_CLUSTERIP_HOST_SVC_CLUSTER_LIST[$j]}
-      process-iperf
+      if [ "$IPERF" == true ]; then
+        process-iperf
+      fi
+      if [ "$HWOL" == true ]; then
+        process-hw-offload-validation
+      fi
     done
   fi
 
@@ -1093,13 +1158,18 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 10 ]; then
       process-curl
     fi
 
-    if [ "$IPERF" == true ]; then
+    if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
       for j in "${!IPERF_CLUSTERIP_HOST_SVC_IPV4_LIST[@]}"
       do
         TEST_SERVER_IPERF_DST=${IPERF_CLUSTERIP_HOST_SVC_IPV4_LIST[$j]}
         TEST_SERVER_IPERF_DST_PORT=$IPERF_CLUSTERIP_HOST_SVC_PORT
         TEST_SERVER_CLUSTER=${IPERF_CLUSTERIP_HOST_SVC_CLUSTER_LIST[$j]}
-        process-iperf
+        if [ "$IPERF" == true ]; then
+          process-iperf
+        fi
+        if [ "$HWOL" == true ]; then
+          process-hw-offload-validation
+        fi
       done
     fi
 
@@ -1158,11 +1228,16 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 11 ] && [ "$FT_HOSTONLY" == false 
     #fi
   fi
 
-  if [ "$IPERF" == true ]; then
+  if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
     TEST_SERVER_IPERF_DST=$IPERF_SERVER_HOST_IP
     TEST_SERVER_IPERF_DST_PORT=$IPERF_NODEPORT_POD_SVC_PORT
     TEST_SERVER_CLUSTER=$MY_CLUSTER
-    process-iperf
+    if [ "$IPERF" == true ]; then
+      process-iperf
+    fi
+    if [ "$HWOL" == true ]; then
+      process-hw-offload-validation
+    fi
   fi
 
   if [ "$OVN_TRACE" == true ]; then
@@ -1219,11 +1294,16 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 11 ] && [ "$FT_HOSTONLY" == false 
       #fi
     fi
 
-    if [ "$IPERF" == true ]; then
+    if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
       TEST_SERVER_IPERF_DST=$IPERF_SERVER_HOST_IP
       TEST_SERVER_IPERF_DST_PORT=$IPERF_NODEPORT_POD_SVC_PORT
       TEST_SERVER_CLUSTER=$MY_CLUSTER
-      process-iperf
+      if [ "$IPERF" == true ]; then
+        process-iperf
+      fi
+      if [ "$HWOL" == true ]; then
+        process-hw-offload-validation
+      fi
     fi
 
     if [ "$OVN_TRACE" == true ]; then
@@ -1283,11 +1363,16 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 12 ] && [ "$FT_CLIENTONLY" == fals
     #fi
   fi
 
-  if [ "$IPERF" == true ]; then
+  if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
     TEST_SERVER_IPERF_DST=$IPERF_SERVER_HOST_IP
     TEST_SERVER_IPERF_DST_PORT=$IPERF_NODEPORT_HOST_SVC_PORT
     TEST_SERVER_CLUSTER=$MY_CLUSTER
-    process-iperf
+    if [ "$IPERF" == true ]; then
+      process-iperf
+    fi
+    if [ "$HWOL" == true ]; then
+      process-hw-offload-validation
+    fi
   fi
 
   if [ "$OVN_TRACE" == true ]; then
@@ -1349,11 +1434,16 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 12 ] && [ "$FT_CLIENTONLY" == fals
       #fi
     fi
 
-    if [ "$IPERF" == true ]; then
+    if [ "$IPERF" == true ] || [ "$HWOL" == true ]; then
       TEST_SERVER_IPERF_DST=$IPERF_SERVER_HOST_IP
       TEST_SERVER_IPERF_DST_PORT=$IPERF_NODEPORT_HOST_SVC_PORT
       TEST_SERVER_CLUSTER=$MY_CLUSTER
-      process-iperf
+      if [ "$IPERF" == true ]; then
+        process-iperf
+      fi
+      if [ "$HWOL" == true ]; then
+        process-hw-offload-validation
+      fi
     fi
 
     if [ "$OVN_TRACE" == true ]; then
@@ -1383,7 +1473,7 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 13 ]; then
     echo
     echo "*** 13-a: Pod -> External Network ***"
     echo
-  
+
     TEST_SERVER_CLUSTER=$EXTERNAL
     TEST_SERVER_NODE=$EXTERNAL
     TEST_FILENAME="13-a-pod2external.txt"

--- a/test.sh
+++ b/test.sh
@@ -77,6 +77,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 1 ] && [ "$FT_HOSTONLY" == false ]
   TEST_SERVER_CLUSTER=$MY_CLUSTER
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="01-a-pod2pod-sameNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   if [ "$CURL" == true ]; then
     TEST_SERVER_HTTP_DST=$HTTP_SERVER_POD_IP
@@ -110,6 +112,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 1 ] && [ "$FT_HOSTONLY" == false ]
   echo
 
   TEST_FILENAME="01-b-pod2pod-diffNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
   TEST_SERVER_CLUSTER=$MY_CLUSTER
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
 
@@ -161,6 +165,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 2 ] && [ "$FT_HOSTONLY" == false ]
   TEST_SERVER_CLUSTER=$MY_CLUSTER
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="02-a-pod2host-sameNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   if [ "$CURL" == true ]; then
     TEST_SERVER_HTTP_DST=$HTTP_SERVER_HOST_IP
@@ -191,6 +197,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 2 ] && [ "$FT_HOSTONLY" == false ]
   TEST_SERVER_CLUSTER=$MY_CLUSTER
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="02-b-pod2host-diffNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   for i in "${!REMOTE_CLIENT_POD_LIST[@]}"
   do
@@ -234,6 +242,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 3 ] && [ "$FT_HOSTONLY" == false ]
   TEST_CLIENT_NODE=$LOCAL_CLIENT_NODE
   TEST_SERVER_NODE=$SERVER_POD_NODE
   TEST_FILENAME="03-a-pod2clusterIpSvc-podBackend-sameNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   if [ "$CURL" == true ]; then
     TEST_SERVER_RSP=$POD_SERVER_STRING
@@ -297,6 +307,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 3 ] && [ "$FT_HOSTONLY" == false ]
 
   TEST_SERVER_NODE=$SERVER_POD_NODE
   TEST_FILENAME="03-b-pod2clusterIpSvc-podBackend-diffNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   for i in "${!REMOTE_CLIENT_POD_LIST[@]}"
   do
@@ -374,6 +386,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 4 ] && [ "$FT_HOSTONLY" == false ]
   TEST_CLIENT_NODE=$LOCAL_CLIENT_NODE
   TEST_SERVER_NODE=$SERVER_POD_NODE
   TEST_FILENAME="04-a-pod2clusterIpSvc-hostBackend-sameNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   if [ "$CURL" == true ]; then
     TEST_SERVER_RSP=$HOST_SERVER_STRING
@@ -437,6 +451,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 4 ] && [ "$FT_HOSTONLY" == false ]
 
   TEST_SERVER_NODE=$SERVER_POD_NODE
   TEST_FILENAME="04-b-pod2clusterIpSvc-hostBackend-diffNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   for i in "${!REMOTE_CLIENT_POD_LIST[@]}"
   do
@@ -514,6 +530,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 5 ] && [ "$FT_HOSTONLY" == false ]
   TEST_CLIENT_NODE=$LOCAL_CLIENT_NODE
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="05-a-pod2nodePortSvc-podBackend-sameNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   if [ "$CURL" == true ]; then
     TEST_SERVER_RSP=$POD_SERVER_STRING
@@ -571,6 +589,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 5 ] && [ "$FT_HOSTONLY" == false ]
     TEST_CLIENT_POD=${REMOTE_CLIENT_POD_LIST[$i]}
     TEST_CLIENT_NODE=${REMOTE_CLIENT_NODE_LIST[$i]}
     TEST_FILENAME="05-b-pod2nodePortSvc-podBackend-diffNode.txt"
+    FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+    REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
     if [ "$CURL" == true ]; then
       TEST_SERVER_RSP=$POD_SERVER_STRING
@@ -634,6 +654,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 6 ] && [ "$FT_HOSTONLY" == false ]
   TEST_CLIENT_NODE=$LOCAL_CLIENT_NODE
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="06-a-pod2nodePortSvc-hostBackend-sameNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   if [ "$CURL" == true ]; then
     TEST_SERVER_RSP=$HOST_SERVER_STRING
@@ -688,6 +710,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 6 ] && [ "$FT_HOSTONLY" == false ]
 
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="06-b-pod2nodePortSvc-hostBackend-diffNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   for i in "${!REMOTE_CLIENT_POD_LIST[@]}"
   do
@@ -757,6 +781,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 7 ] && [ "$FT_HOSTONLY" == false ]
   TEST_SERVER_CLUSTER=$MY_CLUSTER
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="07-a-host2pod-sameNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   if [ "$CURL" == true ]; then
     TEST_SERVER_HTTP_DST=$HTTP_SERVER_POD_IP
@@ -787,6 +813,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 7 ] && [ "$FT_HOSTONLY" == false ]
   TEST_SERVER_CLUSTER=$MY_CLUSTER
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="07-b-host2pod-diffNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   for i in "${!REMOTE_CLIENT_HOST_POD_LIST[@]}"
   do
@@ -831,6 +859,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 8 ] && [ "$FT_CLIENTONLY" == false
   TEST_SERVER_CLUSTER=$MY_CLUSTER
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="08-a-host2host-sameNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   if [ "$CURL" == true ]; then
     TEST_SERVER_HTTP_DST=$HTTP_SERVER_HOST_IP
@@ -868,6 +898,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 8 ] && [ "$FT_CLIENTONLY" == false
   TEST_SERVER_CLUSTER=$MY_CLUSTER
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="08-b-host2host-diffNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   for i in "${!REMOTE_CLIENT_HOST_POD_LIST[@]}"
   do
@@ -918,6 +950,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 9 ] && [ "$FT_HOSTONLY" == false ]
   TEST_CLIENT_NODE=$LOCAL_CLIENT_NODE
   TEST_SERVER_NODE=$SERVER_POD_NODE
   TEST_FILENAME="09-a-host2clusterIpSvc-podBackend-sameNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   if [ "$CURL" == true ]; then
     TEST_SERVER_RSP=$POD_SERVER_STRING
@@ -981,6 +1015,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 9 ] && [ "$FT_HOSTONLY" == false ]
 
   TEST_SERVER_NODE=$SERVER_POD_NODE
   TEST_FILENAME="09-b-host2clusterIpSvc-podBackend-diffNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   for i in "${!REMOTE_CLIENT_HOST_POD_LIST[@]}"
   do
@@ -1058,6 +1094,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 10 ]; then
   TEST_CLIENT_NODE=$LOCAL_CLIENT_NODE
   TEST_SERVER_NODE=$SERVER_POD_NODE
   TEST_FILENAME="10-a-host2clusterIpSvc-hostBackend-sameNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   if [ "$CURL" == true ]; then
     TEST_SERVER_RSP=$HOST_SERVER_STRING
@@ -1121,6 +1159,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 10 ]; then
 
   TEST_SERVER_NODE=$SERVER_POD_NODE
   TEST_FILENAME="10-b-host2clusterIpSvc-hostBackend-diffNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   for i in "${!REMOTE_CLIENT_HOST_POD_LIST[@]}"
   do
@@ -1198,6 +1238,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 11 ] && [ "$FT_HOSTONLY" == false 
   TEST_CLIENT_NODE=$LOCAL_CLIENT_NODE
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="11-a-host2nodePortSvc-podBackend-sameNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   if [ "$CURL" == true ]; then
     TEST_SERVER_RSP=$POD_SERVER_STRING
@@ -1256,6 +1298,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 11 ] && [ "$FT_HOSTONLY" == false 
 
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="11-b-host2nodePortSvc-podBackend-diffNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   for i in "${!REMOTE_CLIENT_HOST_POD_LIST[@]}"
   do
@@ -1331,6 +1375,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 12 ] && [ "$FT_CLIENTONLY" == fals
   TEST_CLIENT_NODE=$LOCAL_CLIENT_NODE
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="12-a-host2nodePortSvc-hostBackend-sameNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   if [ "$CURL" == true ]; then
     TEST_SERVER_RSP=$HOST_SERVER_STRING
@@ -1397,6 +1443,8 @@ if [ "$TEST_CASE" == 0 ] || [ "$TEST_CASE" == 12 ] && [ "$FT_CLIENTONLY" == fals
 
   TEST_SERVER_NODE=$LOCAL_CLIENT_NODE
   TEST_FILENAME="12-b-host2nodePortSvc-hostBackend-diffNode.txt"
+  FORWARD_TEST_FILENAME="${TEST_FILENAME:0:5}client-server-${TEST_FILENAME:5}"
+  REVERSE_TEST_FILENAME="${TEST_FILENAME:0:5}server-client-${TEST_FILENAME:5}"
 
   for i in "${!REMOTE_CLIENT_HOST_POD_LIST[@]}"
   do

--- a/variables.sh
+++ b/variables.sh
@@ -95,6 +95,7 @@ IPERF_CLUSTERIP_HOST_SVC_PORT=${IPERF_CLUSTERIP_HOST_SVC_PORT:-5202}
 IPERF_NODEPORT_POD_SVC_PORT=${IPERF_NODEPORT_POD_SVC_PORT:-30201}
 IPERF_NODEPORT_HOST_SVC_PORT=${IPERF_NODEPORT_HOST_SVC_PORT:-30202}
 
+TOOLS_POD_NAME=${TOOLS_POD_NAME:-ft-tools}
 
 SERVER_PATH=${SERVER_PATH:-"/etc/httpserver/"}
 POD_SERVER_STRING=${POD_SERVER_STRING:-"Server - Pod Backend Reached"}
@@ -441,8 +442,8 @@ query-dynamic-data() {
     # Local Client Node is the same Node Server is running on.
     LOCAL_CLIENT_NODE=$SERVER_POD_NODE
   else
-  	# In Client Only, there are no Server Nodes, so leave blank and logic below
-  	# will pick the first non-Master. 
+    # In Client Only, there are no Server Nodes, so leave blank and logic below
+    # will pick the first non-Master.
     SERVER_POD_NODE=$REMOTE
     SVCNAME_CLUSTER=$UNKNOWN
 
@@ -509,7 +510,7 @@ query-dynamic-data() {
       fi
     fi
   done
-  
+
   #
   # Determine Local and Remote Pods
   #

--- a/variables.sh
+++ b/variables.sh
@@ -43,11 +43,15 @@ CURL_CMD=${CURL_CMD:-curl -m 5}
 IPERF=${IPERF:-false}
 IPERF_CMD=${IPERF_CMD:-iperf3}
 IPERF_TIME=${IPERF_TIME:-10}
+IPERF_FORWARD_TEST_OPT=${IPERF_FORWARD_TEST_OPT:-""}
+IPERF_REVERSE_TEST_OPT=${IPERF_REVERSE_TEST_OPT:-"-R"}
 # Trace Control
 OVN_TRACE=${OVN_TRACE:-false}
 OVN_TRACE_CMD=${OVN_TRACE_CMD:-./ovnkube-trace -loglevel=5 -tcp}
 OVN_K_NAMESPACE=${OVN_K_NAMESPACE:-"ovn-kubernetes"}
 SSL_ENABLE=${SSL_ENABLE:-"-noSSL"}
+# Hardware Offload Validation Control
+HWOL=${HWOL:-false}
 # External Access
 EXTERNAL_IP=${EXTERNAL_IP:-8.8.8.8}
 EXTERNAL_URL=${EXTERNAL_URL:-google.com}
@@ -111,6 +115,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 IPERF_LOGS_DIR="iperf-logs"
 OVN_TRACE_LOGS_DIR="ovn-traces"
+HW_OFFLOAD_LOGS_DIR="hwol-logs"
 
 LOCAL_CLIENT_NODE=
 LOCAL_CLIENT_POD=
@@ -188,6 +193,8 @@ if [ ${COMMAND} == "test" ] ; then
   echo "    IPERF                              $IPERF"
   echo "    IPERF_CMD                          $IPERF_CMD"
   echo "    IPERF_TIME                         $IPERF_TIME"
+  echo "    IPERF_FORWARD_TEST_OPT             $IPERF_FORWARD_TEST_OPT"
+  echo "    IPERF_REVERSE_TEST_OPT             $IPERF_REVERSE_TEST_OPT"
   echo "    FT_CLIENT_CPU_MASK                 $FT_CLIENT_CPU_MASK"
   echo "    OVN_TRACE                          $OVN_TRACE"
   echo "    OVN_TRACE_CMD                      $OVN_TRACE_CMD"
@@ -341,6 +348,9 @@ process-help() {
       echo "                                 VERBOSE=true ./test.sh"
       echo "  IPERF                      - 'iperf3' can be run on each flow, off by default. Example:"
       echo "                                 IPERF=true ./test.sh"
+      echo "  HWOL                       - Hardware Offload Validation can be run on each applicable flow."
+      echo "                               Parameters from IPERF will be used to generate traffic. Example:"
+      echo "                                 HWOL=true ./test.sh"
       echo "  OVN_TRACE                  - 'ovn-trace' can be run on each flow, off by deafult. Example:"
       echo "                                 OVN_TRACE=true ./test.sh"
       echo "  CURL_CMD                   - Curl command to run. Allows additional parameters to be"


### PR DESCRIPTION
Hardware Offload Validation uses "perf3", "tcpdump" and "ethtool"
to determine whether a flow has been hardware offloaded properly.
The expectation is that little to no packets are received on the
VF representors for the client and/or server pods.

In order to get the VF representor for the pods involved, the ft-tools
pod is used with the "crictl" application to get the POD ID.

The ft-tools pod was updated to include "crictl". Also the tools
daemonset was updated to mount the host filesystem (similar to
openshift's debug pod e.g. "oc debug node/<name>"). Also fixed the
node selector to point to "sriov", otherwise the ft-tools won't be
created for the nodes.

Some flows aren't expected to be hardware offloaded; thus the "HWOL"
option would not perform the validation for those flows.